### PR TITLE
Fix wrong storage of start meter values

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ https://github.com/hdering/homematic_verbrauchszaehler
 
 ## Changelog
 
-### 0.2.43
-* (xXBJXx) Fix reset of start values
+### 0.2.44
+* (xXBJXx) Fix wrong storage of start meter values
 
 ### 0.2.41
 * (Dutchman) Fix wrong storage of daily reset of meter values

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You need data as input (total amount of Wh, l/h or m3 used) from your devices an
 
 * [ ] To-Do
 
-This adapter has is roots with thanks to pix back in 2016 
+This adapter has is roots with thanks to pix back in 2016
 https://forum.iobroker.net/viewtopic.php?f=21&t=2262
 
 Which has been improved by @hadering and published on github
@@ -68,6 +68,9 @@ https://github.com/hdering/homematic_verbrauchszaehler
 * [x] ensure all values are stored when adapter shuts down to prevent data gaps
 
 ## Changelog
+
+### 0.2.43
+* (xXBJXx) Fix reset of start values
 
 ### 0.2.41
 * (Dutchman) Fix wrong storage of daily reset of meter values
@@ -141,7 +144,7 @@ https://github.com/hdering/homematic_verbrauchszaehler
 * (Dutchman) implement new translation mechanisme
 
 
-### 0.1.9 
+### 0.1.9
 * (Dutchman) Adapter moved to community development tree
 * (Dutchman) added npm version and test-status to readme
 * (Dutchman) finalized new konfiguration screen & translations

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "sourceanalytix",
-        "version": "0.2.42",
+        "version": "0.2.43",
         "news": {
             "0.2.29": {
                 "en": "Calculation w to kWh implemented & several code improvements",

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "sourceanalytix",
-        "version": "0.2.43",
+        "version": "0.2.44",
         "news": {
             "0.2.29": {
                 "en": "Calculation w to kWh implemented & several code improvements",

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "sourceanalytix",
-        "version": "0.2.43",
+        "version": "0.2.42",
         "news": {
             "0.2.29": {
                 "en": "Calculation w to kWh implemented & several code improvements",

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "sourceanalytix",
-        "version": "0.2.41",
+        "version": "0.2.42",
         "news": {
             "0.2.29": {
                 "en": "Calculation w to kWh implemented & several code improvements",
@@ -14,7 +14,7 @@
                 "es": "Cálculo w a kWh implementado y varias mejoras de código.",
                 "pl": "Wprowadzono obliczenia w do kWh i wprowadzono kilka ulepszeń kodu",
                 "zh-cn": "计算w到kWh实施和几个代码改进"
-            }, 
+            },
             "0.2.27": {
                 "en": "Fixed issue related to multihost installations with slave as target",
                 "de": "Problem bei Multihost-Installationen mit Slave als Ziel behoben",
@@ -26,7 +26,7 @@
                 "es": "Se solucionó el problema relacionado con las instalaciones multihost con esclavo como destino",
                 "pl": "Naprawiono problem związany z instalacjami multihost z niewolnikiem jako celem",
                 "zh-cn": "修复了与slave作为目标的多主机安装相关的问题"
-            }, 
+            },
             "0.2.26": {
                 "en": "Fix issue in calculations for gas environments and liquids",
                 "de": "Problem in Berechnungen für Gasumgebungen und Flüssigkeiten behoben",
@@ -38,7 +38,7 @@
                 "es": "Solucionar el problema en los cálculos para ambientes de gas y líquidos.",
                 "pl": "Napraw problem w obliczeniach dla środowisk gazowych i cieczy",
                 "zh-cn": "解决气体环境和液体计算中的问题"
-            },  
+            },
             "0.2.25": {
                 "en": "add option in state setting to automatically OR manually choose the meassurement unit",
                 "de": "Option in Zustandseinstellung hinzufügen, um die Maßeinheit automatisch ODER manuell auszuwählen",
@@ -50,7 +50,7 @@
                 "es": "Agregue la opción en la configuración de estado para seleccionar automáticamente O manualmente la unidad de medida",
                 "pl": "dodać opcję w ustawieniu stanu, aby automatycznie LUB ręcznie wybrać jednostkę miary",
                 "zh-cn": "在状态设置中添加选项以自动或手动选择测量单位"
-            },  
+            },
             "0.2.24": {
                 "en": "add support for heating pumps",
                 "de": "Unterstützung für Heizungspumpen hinzufügen",
@@ -62,7 +62,7 @@
                 "es": "añadir soporte para bombas de calor",
                 "pl": "dodaj wsparcie dla pomp grzewczych",
                 "zh-cn": "增加对加热泵的支持"
-            },            
+            },
             "0.2.2": {
                 "en": "Final fix for start values, several code improvements",
                 "de": "Endfix für Startwerte, verschiedene Code-Verbesserungen",

--- a/main.js
+++ b/main.js
@@ -239,7 +239,7 @@ class Sourceanalytix extends utils.Adapter {
 			obj.common.custom[inst_name] = {};
 
 			// Reset day counter
-			cron.schedule("0 0 * * *", async () => {
+			cron.schedule("40 0 * * *", async () => {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;

--- a/main.js
+++ b/main.js
@@ -243,10 +243,10 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
+				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value day
-				obj.common.custom[this.namespace].start_day = calc_reading;
+				obj.common.custom[this.namespace].start_day = reading.val;
 				this.log.debug("Object content custom current : " + JSON.stringify(obj));
 
 				this.extendForeignObject(obj_array._id, obj, (err) => {
@@ -254,7 +254,7 @@ class Sourceanalytix extends utils.Adapter {
 						this.log.error("Setting start value Day failed : " + err);
 					} else {
 						this.log.debug("Object content custom after start_day value reset : " + JSON.stringify(obj));
-						this.log.info("Setting start value Day for device : " + obj_array._id + " succeeded with value + " + calc_reading);
+						this.log.info("Setting start value Day for device : " + obj_array._id + " succeeded with value + " + reading.val);
 					}
 				});
 			});
@@ -265,10 +265,10 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
+				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value week
-				obj.common.custom[this.namespace].start_week = calc_reading;
+				obj.common.custom[this.namespace].start_week = reading.val;
 				this.log.debug("Object content custom current : " + JSON.stringify(obj));
 
 				this.extendForeignObject(obj_array._id, obj, (err) => {
@@ -276,7 +276,7 @@ class Sourceanalytix extends utils.Adapter {
 						this.log.error("Setting start value Week failed : " + err);
 					} else {
 						this.log.debug("Object content custom after start_day value reset : " + JSON.stringify(obj));
-						this.log.info("Setting start value Week for device : " + obj_array._id + " succeeded with value + " + calc_reading);
+						this.log.info("Setting start value Week for device : " + obj_array._id + " succeeded with value + " + reading.val);
 					}
 				});
 			});
@@ -287,10 +287,10 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
+				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value month
-				obj.common.custom[this.namespace].start_month = calc_reading;
+				obj.common.custom[this.namespace].start_month = reading.val;
 				this.log.debug("Object content custom current : " + JSON.stringify(obj));
 
 				this.extendForeignObject(obj_array._id, obj, (err) => {
@@ -298,7 +298,7 @@ class Sourceanalytix extends utils.Adapter {
 						this.log.error("Setting start value month failed : " + err);
 					} else {
 						this.log.debug("Object content custom after start_day value reset : " + JSON.stringify(obj));
-						this.log.info("Setting start value month for device : " + obj_array._id + " succeeded with value + " + calc_reading);
+						this.log.info("Setting start value month for device : " + obj_array._id + " succeeded with value + " + reading.val);
 					}
 				});
 			});
@@ -309,10 +309,10 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
+				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value quarter
-				obj.common.custom[this.namespace].start_quarter = calc_reading;
+				obj.common.custom[this.namespace].start_quarter = reading.val;
 				this.log.debug("Object content custom current : " + JSON.stringify(obj));
 
 				this.extendForeignObject(obj_array._id, obj, (err) => {
@@ -320,7 +320,7 @@ class Sourceanalytix extends utils.Adapter {
 						this.log.error("Setting start value quarter failed : " + err);
 					} else {
 						this.log.debug("Object content custom after start_day value reset : " + JSON.stringify(obj));
-						this.log.info("Setting start value quarter for device : " + obj_array._id + " succeeded with value + " + calc_reading);
+						this.log.info("Setting start value quarter for device : " + obj_array._id + " succeeded with value + " + reading.val);
 					}
 				});
 			});
@@ -331,10 +331,10 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
+				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value year
-				obj.common.custom[this.namespace].start_year = calc_reading;
+				obj.common.custom[this.namespace].start_year = reading.val;
 				this.log.debug("Object content custom current : " + JSON.stringify(obj));
 
 				this.extendForeignObject(obj_array._id, obj, (err) => {
@@ -342,7 +342,7 @@ class Sourceanalytix extends utils.Adapter {
 						this.log.error("Setting start value year failed : " + err);
 					} else {
 						this.log.debug("Object content custom after start_day value reset : " + JSON.stringify(obj));
-						this.log.info("Setting start value year for device : " + obj_array._id + " succeeded with value + " + calc_reading);
+						this.log.info("Setting start value year for device : " + obj_array._id + " succeeded with value + " + reading.val);
 					}
 				});
 			});
@@ -379,49 +379,6 @@ class Sourceanalytix extends utils.Adapter {
 				break;
 			case "l":
 				calc_value = value / 1000;
-				break;
-			case "w":
-				calc_value = value;
-				break;
-			default:
-				this.log.error("Case error : value received for calculation with unit : " + unit + " which is currenlty not (yet) supported");
-		}
-
-		if (calc_value === null) {
-			this.log.error("Data error ! NULL value received for current reading of device : " + obj._id);
-		}
-
-		this.log.debug("State value output of unit factore calculation : " + JSON.stringify(calc_value));
-
-		return calc_value;
-	}
-
-	// Unit list without conversion for the reset start values for each day, week, month, quarter, year
-	unit_calc_fact1(obj, value) {
-		this.log.debug("Object array input for unit factore calculation : " + JSON.stringify(obj));
-		this.log.debug("State value input for unit factore calculation : " + JSON.stringify(value));
-		if (value === null) {
-			this.log.error("Data error ! NULL value received for current reading of device : " + obj._id);
-		}
-
-		const unit = this.defineUnit(obj);
-
-		this.log.debug("Test unit : " + unit);
-
-		let calc_value;
-
-		switch (unit) {
-			case "kwh":
-				calc_value = value;
-				break;
-			case "wh":
-				calc_value = value;
-				break;
-			case "m3":
-				calc_value = value;
-				break;
-			case "l":
-				calc_value = value;
 				break;
 			case "w":
 				calc_value = value;

--- a/main.js
+++ b/main.js
@@ -936,6 +936,7 @@ class Sourceanalytix extends utils.Adapter {
 
 }
 
+
 //@ts-ignore .parent exists
 if (module.parent) {
 	// Export the constructor in compact mode

--- a/main.js
+++ b/main.js
@@ -994,4 +994,5 @@ if (module.parent) {
 } else {
 	// otherwise start the instance directly
 	new Sourceanalytix();
+
 }

--- a/main.js
+++ b/main.js
@@ -239,7 +239,7 @@ class Sourceanalytix extends utils.Adapter {
 			obj.common.custom[inst_name] = {};
 
 			// Reset day counter
-			cron.schedule("40 0 * * *", async () => {
+			cron.schedule("0 1 * * *", async () => {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;

--- a/main.js
+++ b/main.js
@@ -396,7 +396,7 @@ class Sourceanalytix extends utils.Adapter {
 		return calc_value;
 	}
 
-	// Ensure always the calculation factor is correctly applied (example Wh to kWh, we calculate always in kilo)
+	// Unit list without conversion for the reset start values for each day, week, month, quarter, year
 	unit_calc_fact1(obj, value) {
 		this.log.debug("Object array input for unit factore calculation : " + JSON.stringify(obj));
 		this.log.debug("State value input for unit factore calculation : " + JSON.stringify(value));

--- a/main.js
+++ b/main.js
@@ -220,7 +220,7 @@ class Sourceanalytix extends utils.Adapter {
 		let existing = false;
 		for (const x in cron_set) {
 
-			// check if cronjob is already running, if not initiate 
+			// check if cronjob is already running, if not initiate
 			if (cron_set[x] === obj_array._id) {
 				existing = true;
 			}
@@ -243,7 +243,7 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact(obj_array, reading.val);
+				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
 
 				// Extend object with start value day
 				obj.common.custom[this.namespace].start_day = calc_reading;
@@ -265,7 +265,7 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact(obj_array, reading.val);
+				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
 
 				// Extend object with start value week
 				obj.common.custom[this.namespace].start_week = calc_reading;
@@ -287,7 +287,7 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact(obj_array, reading.val);
+				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
 
 				// Extend object with start value month
 				obj.common.custom[this.namespace].start_month = calc_reading;
@@ -309,7 +309,7 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact(obj_array, reading.val);
+				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
 
 				// Extend object with start value quarter
 				obj.common.custom[this.namespace].start_quarter = calc_reading;
@@ -331,7 +331,7 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				const calc_reading = this.unit_calc_fact(obj_array, reading.val);
+				const calc_reading = this.unit_calc_fact1(obj_array, reading.val);
 
 				// Extend object with start value year
 				obj.common.custom[this.namespace].start_year = calc_reading;
@@ -379,6 +379,49 @@ class Sourceanalytix extends utils.Adapter {
 				break;
 			case "l":
 				calc_value = value / 1000;
+				break;
+			case "w":
+				calc_value = value;
+				break;
+			default:
+				this.log.error("Case error : value received for calculation with unit : " + unit + " which is currenlty not (yet) supported");
+		}
+
+		if (calc_value === null) {
+			this.log.error("Data error ! NULL value received for current reading of device : " + obj._id);
+		}
+
+		this.log.debug("State value output of unit factore calculation : " + JSON.stringify(calc_value));
+
+		return calc_value;
+	}
+
+	// Ensure always the calculation factor is correctly applied (example Wh to kWh, we calculate always in kilo)
+	unit_calc_fact1(obj, value) {
+		this.log.debug("Object array input for unit factore calculation : " + JSON.stringify(obj));
+		this.log.debug("State value input for unit factore calculation : " + JSON.stringify(value));
+		if (value === null) {
+			this.log.error("Data error ! NULL value received for current reading of device : " + obj._id);
+		}
+
+		const unit = this.defineUnit(obj);
+
+		this.log.debug("Test unit : " + unit);
+
+		let calc_value;
+
+		switch (unit) {
+			case "kwh":
+				calc_value = value;
+				break;
+			case "wh":
+				calc_value = value;
+				break;
+			case "m3":
+				calc_value = value;
+				break;
+			case "l":
+				calc_value = value;
 				break;
 			case "w":
 				calc_value = value;
@@ -595,7 +638,7 @@ class Sourceanalytix extends utils.Adapter {
 
 			this.log.silly("Current reading state : " + delivery + device + state_root);
 
-			// Create meassurement state used for calculations related w to kWh 
+			// Create meassurement state used for calculations related w to kWh
 			if (w_calc === true) {
 				state_root = ".Current_Reading_W";
 				await this.doStateCreate(delivery, device, state_root, "Current Reading W", "number", "value.current", "W", false, false, true);
@@ -625,7 +668,7 @@ class Sourceanalytix extends utils.Adapter {
 		let cost_t, del_t, cost_basic, cost_unit;
 		this.log.debug("Write calculations for : " + id._id);
 		this.log.debug("Instance name : " + inst_name);
-		
+
 		const date = new Date();
 
 		// replace "." in datapoints to "_"
@@ -779,7 +822,7 @@ class Sourceanalytix extends utils.Adapter {
 		this.log.debug("Handle meter history : " + obj_cust.meter_values);
 
 		// temporary set to sero, this value will be used later to handle period calculations
-		const reading_start = 0; //obj_cust.start_meassure; 
+		const reading_start = 0; //obj_cust.start_meassure;
 		const day_bval = obj_cust.start_day;
 		const week_bval = obj_cust.start_week;
 		const month_bval = obj_cust.start_month;
@@ -936,7 +979,7 @@ class Sourceanalytix extends utils.Adapter {
 		}
 
 		return unit;
-		
+
 	}
 
 }

--- a/main.js
+++ b/main.js
@@ -239,7 +239,7 @@ class Sourceanalytix extends utils.Adapter {
 			obj.common.custom[inst_name] = {};
 
 			// Reset day counter
-			cron.schedule("0 1 * * *", async () => {
+			cron.schedule("0 0 * * *", async () => {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;

--- a/main.js
+++ b/main.js
@@ -243,7 +243,6 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value day
 				obj.common.custom[this.namespace].start_day = reading.val;
@@ -265,7 +264,6 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value week
 				obj.common.custom[this.namespace].start_week = reading.val;
@@ -287,7 +285,6 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value month
 				obj.common.custom[this.namespace].start_month = reading.val;
@@ -309,7 +306,6 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value quarter
 				obj.common.custom[this.namespace].start_quarter = reading.val;
@@ -331,7 +327,6 @@ class Sourceanalytix extends utils.Adapter {
 				// get current meter value
 				const reading = await this.getForeignStateAsync(obj_array.MeterReading);
 				if (!reading) return;
-				//const calc_reading = this.unit_calc_fact(obj_array, reading.val);
 
 				// Extend object with start value year
 				obj.common.custom[this.namespace].start_year = reading.val;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.43",
+  "version": "0.2.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "SourceAnalytix",
   "author": {
     "name": "DutchmanNL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.43",
+  "version": "0.2.42",
   "description": "SourceAnalytix",
   "author": {
     "name": "DutchmanNL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "SourceAnalytix",
   "author": {
     "name": "DutchmanNL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.sourceanalytix",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "SourceAnalytix",
   "author": {
     "name": "DutchmanNL",


### PR DESCRIPTION
Die Start Zählerstand wurden falsch gesetzt beim zurücksetzen um 0 Uhr  da er bereits umgerechnete Zählerstand nochmals umgerechnet hat und diese dann als Start Zählerstand gesetzt hat.
