### PR TITLE
fix(dependabot): use cronjob key for cron schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: cron
-      cron: "37 3 11 * *"
+      cronjob: "37 3 11 * *"
       timezone: Europe/Berlin
     cooldown:
       default-days: 7
@@ -18,6 +18,6 @@ updates:
     directory: "/"
     schedule:
       interval: cron
-      cron: "17 4 23 * *"
+      cronjob: "17 4 23 * *"
       timezone: Europe/Berlin
     open-pull-requests-limit: 30


### PR DESCRIPTION
## Problem

The cron schedules introduced in c014a91 fail Dependabot's config validation:

```
The property '#/updates/0/schedule' contains additional properties ["cron"] outside of the schema when none are allowed
The property '#/updates/1/schedule' contains additional properties ["cron"] outside of the schema when none are allowed
```

`interval: cron` is correct and selects cron-based scheduling, but the expression itself does not go under a `cron` key — it belongs under `cronjob`.

## Fix

Rename `cron:` to `cronjob:` in both update entries. The expressions and timezones are unchanged, and remain valid five-field cron syntax with the timezone kept in its own parameter (which the docs require — it must not be embedded in the cron expression).

```diff
     schedule:
       interval: cron
-      cron: "37 3 11 * *"
+      cronjob: "37 3 11 * *"
       timezone: Europe/Berlin
```

## Verification

Validated `.github/dependabot.yml` against [`json.schemastore.org/dependabot-2.0.json`](https://json.schemastore.org/dependabot-2.0.json), the schema behind the reported error:

| file | result |
|---|---|
| before | 4 errors — `'cronjob' is a required property` at `updates[0].schedule` and `updates[1].schedule` |
| after | valid |

Both sources agree on the key name:

- The schema conditions on `interval: "cron"` and then declares `cronjob` as `required`.
- The [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cronjob) documents `cronjob` as *"Defines the cron expression if the interval type is `cron`"*, and notes that a `cronjob` schedule is required to use a `cron` interval.

Addresses the S8906 suggestion from #1179 (migrate off `interval: monthly` to distribute load), which the previous commit intended but got wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)