### PR TITLE
feat: optionally ignore negative power readings (#466)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When the adapter crashes or another code error occurs, the error message which a
 - Fixed, scheduled, state-provided and selector-controlled unit prices
 - Timestamped price history which preserves already calculated costs
 - Automatic conversion between compatible energy, volume, mass and metric length units
-- Integration of power readings over their actual update intervals
+- Integration of power readings over their actual update intervals, optionally ignoring negative readings
 - Recovery of missed calendar rollovers after an adapter restart
 - Handling of meter resets, meter replacements and small backwards fluctuations
 
@@ -121,6 +121,7 @@ SourceAnalytix is configured through the ioBroker custom settings of each source
 | Including basic rate | Adds the price definition's monthly basic price. |
 | Calculate consumption | Creates and updates consumption or delivery states. |
 | Average power values between updates | Optional calculation mode for power states; see [Power states](#power-states). |
+| Ignore negative power values | Counts negative power readings as `0 W`; see [Power states](#power-states). |
 | Store Meter Values | Stores meter readings in the enabled period collections. |
 | Device value reset detection | Continues a cumulative total after a meter reset or replacement. |
 | Threshold | Largest backwards fluctuation ignored as measurement jitter, expressed in the target unit. |
@@ -150,6 +151,8 @@ Enter manual start values in the **target unit** selected by the price definitio
 Power values such as `W` or `kW` are integrated over the actual time between state updates to produce energy. The first reading establishes the baseline and does not create consumption.
 
 By default, the previous power value is treated as valid for the complete interval. Enable **Average power values between updates** for sensors which report regularly and change gradually; SourceAnalytix then uses the average of the previous and current values. Leave it disabled for devices that switch abruptly when the update marks the switch event.
+
+Some inverters report a strongly negative power while they are switched off, which would otherwise be integrated as negative energy and reduce the accumulated yield. Enable **Ignore negative power values** to count such readings as `0 W`. The reading is clamped rather than discarded, so the interval still advances; discarding it would keep the last positive power as the baseline and integrate it across the whole downtime.
 
 ### Supported units
 
@@ -250,6 +253,9 @@ This is a personal donation link for DutchmanNL and is not related to the ioBrok
     ### __WORK IN PROGRESS__
 -->
 ## Changelog
+### __WORK IN PROGRESS__
+* Power states can optionally ignore negative readings, so inverters which report a negative power while switched off no longer reduce the accumulated yield ([#466](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/466)).
+
 ### 0.5.2 (2026-07-28)
 * The npm release workflow no longer fails at the Sentry step: commit association is disabled because the previous release commit is not reachable in the shallow, squash-merged history ([#1179](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/1179)).
 * README now carries the standard Sentry notice required by the ioBroker repository checker ([#1179](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/1179)).

--- a/admin/i18n/de.json
+++ b/admin/i18n/de.json
@@ -113,5 +113,7 @@
     "cm": "cm",
     "mm": "mm",
     "nm": "nm",
-    "µm": "µm"
+    "µm": "µm",
+    "Ignore negative power values": "Negative Leistungswerte ignorieren",
+    "Ignore negative power values help": "Wirkt nur bei Leistungswerten (W/kW). Negative Messwerte zählen als 0 W. Für Wechselrichter aktivieren, die im abgeschalteten Zustand eine negative Leistung melden."
 }

--- a/admin/i18n/en.json
+++ b/admin/i18n/en.json
@@ -113,5 +113,7 @@
     "cm": "cm",
     "mm": "mm",
     "nm": "nm",
-    "µm": "µm"
+    "µm": "µm",
+    "Ignore negative power values": "Ignore negative power values",
+    "Ignore negative power values help": "Only affects power values (W/kW). Negative readings count as 0 W. Enable for inverters that report a negative power while they are switched off."
 }

--- a/admin/i18n/es.json
+++ b/admin/i18n/es.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Ignorar valores de potencia negativos",
+    "Ignore negative power values help": "Solo afecta a los valores de potencia (W/kW). Las lecturas negativas cuentan como 0 W. Actívalo para inversores que indican una potencia negativa cuando están apagados."
 }

--- a/admin/i18n/fr.json
+++ b/admin/i18n/fr.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Ignorer les valeurs de puissance négatives",
+    "Ignore negative power values help": "Affecte uniquement les valeurs de puissance (W/kW). Les relevés négatifs comptent pour 0 W. Activez cette option pour les onduleurs qui indiquent une puissance négative lorsqu’ils sont éteints."
 }

--- a/admin/i18n/it.json
+++ b/admin/i18n/it.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Ignora i valori di potenza negativi",
+    "Ignore negative power values help": "Riguarda solo i valori di potenza (W/kW). Le letture negative valgono 0 W. Attiva per gli inverter che segnalano una potenza negativa quando sono spenti."
 }

--- a/admin/i18n/nl.json
+++ b/admin/i18n/nl.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Negatieve vermogenswaarden negeren",
+    "Ignore negative power values help": "Heeft alleen invloed op vermogenswaarden (W/kW). Negatieve metingen tellen als 0 W. Schakel dit in voor omvormers die een negatief vermogen melden terwijl ze uitgeschakeld zijn."
 }

--- a/admin/i18n/pl.json
+++ b/admin/i18n/pl.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Ignoruj ujemne wartości mocy",
+    "Ignore negative power values help": "Dotyczy tylko wartości mocy (W/kW). Ujemne odczyty liczone są jako 0 W. Włącz dla falowników, które w stanie wyłączonym zgłaszają ujemną moc."
 }

--- a/admin/i18n/pt.json
+++ b/admin/i18n/pt.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Ignorar valores de potência negativos",
+    "Ignore negative power values help": "Afeta apenas valores de potência (W/kW). Leituras negativas contam como 0 W. Ative para inversores que indicam potência negativa quando estão desligados."
 }

--- a/admin/i18n/ru.json
+++ b/admin/i18n/ru.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Игнорировать отрицательные значения мощности",
+    "Ignore negative power values help": "Влияет только на значения мощности (Вт/кВт). Отрицательные показания считаются как 0 Вт. Включите для инверторов, которые сообщают отрицательную мощность в выключенном состоянии."
 }

--- a/admin/i18n/uk.json
+++ b/admin/i18n/uk.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "Ігнорувати від’ємні значення потужності",
+    "Ignore negative power values help": "Впливає лише на значення потужності (Вт/кВт). Від’ємні покази зараховуються як 0 Вт. Увімкніть для інверторів, які у вимкненому стані повідомляють від’ємну потужність."
 }

--- a/admin/i18n/zh-cn.json
+++ b/admin/i18n/zh-cn.json
@@ -113,5 +113,7 @@
     "enabled": "enabled",
     "number of days": "Number of days",
     "number of months": "Number of months",
-    "period of time": "Period of time"
+    "period of time": "Period of time",
+    "Ignore negative power values": "忽略负功率值",
+    "Ignore negative power values help": "仅影响功率值（W/kW）。负读数按 0 W 计。对于关机时报告负功率的逆变器请启用此选项。"
 }

--- a/admin/jsonCustom.json
+++ b/admin/jsonCustom.json
@@ -85,6 +85,17 @@
       "lg": 6,
       "xl": 6
     },
+    "ignoreNegativeValues": {
+      "type": "checkbox",
+      "label": "Ignore negative power values",
+      "tooltip": "Ignore negative power values help",
+      "default": false,
+      "xs": 12,
+      "sm": 6,
+      "md": 6,
+      "lg": 6,
+      "xl": 6
+    },
     "meter_values": {
       "type": "checkbox",
       "label": "Store Meter Values",

--- a/calculation.test.js
+++ b/calculation.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const {calculatePowerEnergy} = require('./lib/calculation');
+const {calculatePowerEnergy, normalizePowerReading} = require('./lib/calculation');
 
 describe('Power-to-energy calculation', () => {
 	const start = Date.UTC(2026, 0, 1, 10);
@@ -21,5 +21,38 @@ describe('Power-to-energy calculation', () => {
 
 	it('rejects readings whose timestamp moves backwards', () => {
 		assert.equal(calculatePowerEnergy(100, 300, fifteenMinutesLater, start, true), null);
+	});
+});
+
+describe('Negative power readings', () => {
+	const start = Date.UTC(2026, 0, 1, 20);
+	const fifteenMinutesLater = start + 15 * 60 * 1000;
+
+	it('passes readings through unchanged while the option is disabled', () => {
+		assert.equal(normalizePowerReading(-3000, false), -3000);
+		assert.equal(normalizePowerReading(250, false), 250);
+	});
+
+	it('treats a negative reading as zero watts while the option is enabled', () => {
+		assert.equal(normalizePowerReading(-3000, true), 0);
+	});
+
+	it('leaves positive readings and zero untouched', () => {
+		assert.equal(normalizePowerReading(250, true), 250);
+		assert.equal(normalizePowerReading(0, true), 0);
+	});
+
+	it('does not coerce non-finite readings, so they stay detectable as invalid', () => {
+		assert.ok(Number.isNaN(normalizePowerReading(Number.NaN, true)));
+	});
+
+	it('contributes no energy once a switched-off inverter is clamped', () => {
+		const clamped = normalizePowerReading(-3000, true);
+		assert.equal(calculatePowerEnergy(clamped, clamped, start, fifteenMinutesLater, false), 0);
+		assert.equal(calculatePowerEnergy(clamped, clamped, start, fifteenMinutesLater, true), 0);
+	});
+
+	it('would otherwise subtract energy from the total', () => {
+		assert.equal(calculatePowerEnergy(-3000, -3000, start, fifteenMinutesLater, false), -750);
 	});
 });

--- a/io-package.json
+++ b/io-package.json
@@ -3,6 +3,19 @@
     "name": "sourceanalytix",
     "version": "0.5.2",
     "news": {
+      "0.5.3": {
+        "en": "Power states can optionally ignore negative readings, so inverters which report a negative power while switched off no longer reduce the accumulated yield",
+        "de": "Leistungs-Datenpunkte können negative Messwerte optional ignorieren, damit Wechselrichter, die im abgeschalteten Zustand eine negative Leistung melden, den aufsummierten Ertrag nicht mehr verringern",
+        "ru": "Состояния мощности могут при желании игнорировать отрицательные показания, чтобы инверторы, сообщающие отрицательную мощность в выключенном состоянии, больше не уменьшали накопленную выработку",
+        "pt": "Os estados de potência podem opcionalmente ignorar leituras negativas, para que os inversores que indicam potência negativa quando desligados deixem de reduzir a produção acumulada",
+        "nl": "Vermogensdatapunten kunnen negatieve metingen optioneel negeren, zodat omvormers die in uitgeschakelde toestand een negatief vermogen melden de opgetelde opbrengst niet langer verlagen",
+        "fr": "Les états de puissance peuvent ignorer en option les relevés négatifs, afin que les onduleurs indiquant une puissance négative à l’arrêt ne réduisent plus la production cumulée",
+        "it": "Gli stati di potenza possono facoltativamente ignorare le letture negative, così gli inverter che segnalano una potenza negativa da spenti non riducono più la produzione accumulata",
+        "es": "Los estados de potencia pueden ignorar opcionalmente las lecturas negativas, de modo que los inversores que indican una potencia negativa cuando están apagados ya no reducen la producción acumulada",
+        "pl": "Stany mocy mogą opcjonalnie ignorować ujemne odczyty, dzięki czemu falowniki zgłaszające ujemną moc w stanie wyłączonym nie zmniejszają już zsumowanego uzysku",
+        "zh-cn": "功率状态可选择忽略负读数，使关机时报告负功率的逆变器不再减少累计发电量",
+        "uk": "Стани потужності можуть за бажанням ігнорувати від’ємні покази, щоб інвертори, які у вимкненому стані повідомляють від’ємну потужність, більше не зменшували накопичений виробіток"
+      },
       "0.5.2": {
         "en": "The npm release workflow no longer fails at the Sentry step because commit association is disabled\nThe README now contains the standard Sentry notice required by the ioBroker repository checker",
         "de": "Der npm-Release-Workflow scheitert nicht mehr am Sentry-Schritt, da die Commit-Zuordnung deaktiviert ist\nDie README enthält jetzt den standardmäßigen Sentry-Hinweis, den der ioBroker-Repository-Checker verlangt",
@@ -80,19 +93,6 @@
         "pl": "Poprawiono komunikaty dziennika i błędów podczas uruchamiania adaptera\nPoprawka: rozwiązano \"Cannot read property 'calcValues' of null\" oraz powiązane problemy wykryte przez Sentry",
         "zh-cn": "改进了适配器启动时的日志与错误消息\n修复：解决了 \"Cannot read property 'calcValues' of null\" 及 Sentry 发现的相关问题",
         "uk": "Покращено повідомлення журналу та помилок під час запуску адаптера\nВиправлення: усунено \"Cannot read property 'calcValues' of null\" та пов'язані проблеми, виявлені Sentry"
-      },
-      "0.4.10": {
-        "en": "Bugfix : Avoid adapter crash during night for incorrect configured states #460",
-        "de": "Bugfix: Adapterabsturz während der Nacht bei falsch konfigurierten Datenpunkten vermieden #460",
-        "ru": "Исправление: предотвращён сбой адаптера ночью из-за неправильно настроенных состояний #460",
-        "pt": "Correção: evitada a falha do adaptador durante a noite devido a estados mal configurados #460",
-        "nl": "Bugfix: voorkomen dat de adapter 's nachts crasht door onjuist geconfigureerde datapunten #460",
-        "fr": "Correction : plantage de l'adaptateur pendant la nuit évité pour des états mal configurés #460",
-        "it": "Bugfix: evitato l'arresto anomalo dell'adattatore durante la notte per stati configurati in modo errato #460",
-        "es": "Corrección: evitado el bloqueo del adaptador durante la noche por estados mal configurados #460",
-        "pl": "Poprawka: uniknięto awarii adaptera w nocy z powodu nieprawidłowo skonfigurowanych stanów #460",
-        "zh-cn": "修复：避免适配器在夜间因状态配置错误而崩溃 #460",
-        "uk": "Виправлення: усунено збій адаптера вночі через неправильно налаштовані стани #460"
       }
     },
     "titleLang": {

--- a/lib/calculation.js
+++ b/lib/calculation.js
@@ -298,6 +298,21 @@ function calculateBasicPriceTotals(monthlyPrice, date) {
 }
 
 /**
+ * Normalize a raw power reading before it is integrated over an interval.
+ * Some inverters report a strongly negative power while they are switched off.
+ * Such a reading is clamped to zero instead of being dropped, so the interval
+ * still advances and contributes no energy. Dropping it would keep the last
+ * positive power as the baseline and integrate it across the whole downtime.
+ * @param {number} value - Raw power reading in watts
+ * @param {boolean} ignoreNegativeValues - Whether negative readings count as zero
+ * @returns {number} Power reading to use for the calculation
+ */
+function normalizePowerReading(value, ignoreNegativeValues) {
+	if (!ignoreNegativeValues || !Number.isFinite(value)) return value;
+	return value < 0 ? 0 : value;
+}
+
+/**
  * Calculate the energy represented by two timestamped power readings.
  * @param {number} previousPower - Power at the beginning of the interval in watts
  * @param {number} currentPower - Power at the end of the interval in watts
@@ -334,5 +349,6 @@ module.exports = {
 	getPeriodChanges,
 	initializePeriodStartValues,
 	normalizePeriodSnapshot,
+	normalizePowerReading,
 	resolveCumulativeReading,
 };

--- a/main.js
+++ b/main.js
@@ -1098,6 +1098,7 @@ class Sourceanalytix extends utils.Adapter {
 						stateUnit: useUnit,
 						useUnit: selectedPriceConfig.unitType,
 						deviceResetLogicEnabled: customData.deviceResetLogicEnabled ?? true,
+						ignoreNegativeValues: customData.ignoreNegativeValues === true,
 						threshold: customData.threshold ?? 1,
 					},
 					calcValues: {
@@ -2313,10 +2314,15 @@ class Sourceanalytix extends utils.Adapter {
 			this.log.debug(`[wattToWattHour] Watt to kWh, current reading : ${value.val} previousReading : ${JSON.stringify(calcValues)}`);
 
 			// Prepare needed data to handle calculations
+			const rawReadingWatt = Number(value.val);
+			const currentReadingWatt = calculation.normalizePowerReading(rawReadingWatt, stateDetails.ignoreNegativeValues);
+			if (currentReadingWatt !== rawReadingWatt) {
+				this.log.debug(`[wattToWattHour] ${stateID} negative power reading ${rawReadingWatt} treated as 0 W`);
+			}
 			const readingData = {
 				previousReadingWatt: Number(calcValues.previousReadingWatt),
 				previousReadingWattTs: Number(calcValues.previousReadingWattTs),
-				currentReadingWatt: Number(value.val),
+				currentReadingWatt: currentReadingWatt,
 				currentReadingWattTs: Number(value.ts),
 			};
 


### PR DESCRIPTION
Closes #466.

### The problem

`calculatePowerEnergy` never checked the sign of a power reading. A PV inverter that reports a strongly negative power while switched off had that value integrated over the interval like any other reading, producing negative energy and pulling the accumulated yield back down. Confirmed still present on v0.5.2 before this change.

### The change

A per-source checkbox **Ignore negative power values**, next to the existing *Average power values between updates*. When enabled, a negative reading is clamped to `0 W` by a new `normalizePowerReading()` helper before the energy calculation runs.

**Why clamp instead of discard.** Dropping the sample would leave the last positive power as the baseline *with its old timestamp*. The next accepted reading would then integrate that power across the entire downtime — for an inverter that means roughly 10 hours × the last daylight power invented as energy. Clamping lets the interval advance and contributes nothing, which is what a switched-off inverter should record. Both the default and the averaging mode are covered, because the raw sample is normalized before either formula sees it.

Scope is power sources only. Backwards movement of a cumulative meter is already handled by the existing reset/jitter classification, where clamping would be wrong.

### Contents

- `normalizePowerReading()` in `lib/calculation.js`, applied in `wattToWattHour()` with a debug log when a reading is clamped
- setting read into `stateDetails` in `buildStateDetailsArray`, defaulting to `false` so existing sources are unaffected
- checkbox in `admin/jsonCustom.json`, label and tooltip translated into all 11 admin languages
- 6 unit tests, including one asserting the old behaviour (`-750 Wh` for an unclamped interval) so the regression stays visible
- README *Power states* section, feature list and settings table
- `0.5.3` `common.news` entry, hand-translated, so `release-script` skips its translation service

### Verification

- `npm run test` — 58 passing; `npm run test:js` — 52 passing
- `npm run lint` clean
- `release-script patch --all --dry` logs `current news is already in io-package.json, not changing it`, no translation fatal

**Note on versioning:** the news key is `0.5.3`, assuming a patch release. If you cut this as a minor instead, rename that key to `0.6.0` first — otherwise the release script falls through to the translation service and aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)