### PR TITLE
Add per-source statistics JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ When the adapter crashes or another code error occurs, the error message which a
 - Integration of power readings over their actual update intervals, optionally ignoring negative readings
 - Recovery of missed calendar rollovers after an adapter restart
 - Handling of meter resets, meter replacements and small backwards fluctuations
+- One compact, automatically updated statistics JSON state per active source
 
 ## Setup
 
@@ -181,8 +182,69 @@ For every source, SourceAnalytix creates a `cumulativeReading` and the enabled r
 | `<source>.currentYear.earnings` | Current earnings totals. |
 | `<source>.currentYear.meterReadings` | Optional meter readings by enabled periods. |
 | `<source>.<year>` | Optional archived week, month and quarter statistics. |
+| `<source>.statisticsJson` | Compact current-year statistics for VIS, scripts and other adapters. |
 
 The basic current and optional previous states use names such as `01_currentDay`, `02_currentWeek`, `03_currentMonth`, `04_currentQuarter`, `05_currentYear` and their `previous` equivalents.
+
+### Statistics JSON
+
+Every active source automatically exposes a read-only `statisticsJson` state with role `json`; no additional setting is required. It contains the same calculated values as the individual states and does not perform a separate calculation.
+
+```json
+{
+  "schemaVersion": 1,
+  "year": 2026,
+  "source": {
+    "id": "smartmeter.0.total",
+    "name": "Electricity meter",
+    "unit": "kWh"
+  },
+  "quantity": {
+    "type": "consumed",
+    "current": {
+      "day": 4.21,
+      "week": 28.65,
+      "month": 114.32,
+      "quarter": 301.77,
+      "year": 894.15
+    },
+    "previous": null,
+    "periods": {
+      "weekdays": null,
+      "previousWeekdays": null,
+      "weeks": {},
+      "months": {},
+      "quarters": {}
+    }
+  },
+  "financial": {
+    "type": "costs",
+    "currency": "EUR",
+    "current": {
+      "day": 1.24,
+      "week": 8.47,
+      "month": 34.19,
+      "quarter": 89.51,
+      "year": 261.42
+    },
+    "previous": null,
+    "periods": {
+      "weekdays": null,
+      "previousWeekdays": null,
+      "weeks": {},
+      "months": {},
+      "quarters": {}
+    }
+  },
+  "meterReadings": null
+}
+```
+
+`quantity` represents either `consumed` or `delivered` values. `financial` represents either `costs` or `earnings`. `meterReadings` is populated when meter-value storage is enabled. Disabled calculations and period collections are represented by `null`, so the schema remains predictable.
+
+Weekdays use `1` for Monday through `7` for Sunday. Week and month keys are zero-padded, and quarter keys use `1` through `4`. Only current-year collections and the optional previous-period values are included, preventing the state from growing indefinitely. The ioBroker state timestamp indicates when the JSON was last changed.
+
+The state is rebuilt from existing statistics when the adapter starts and its writes are bundled during normal calculations. If a source is disabled or deleted, the last JSON value is retained together with the other calculated history and is no longer updated.
 
 ## Meter Resets And Corrections
 
@@ -253,6 +315,9 @@ This is a personal donation link for DutchmanNL and is not related to the ioBrok
     ### __WORK IN PROGRESS__
 -->
 ## Changelog
+### __WORK IN PROGRESS__
+* Each active source automatically exposes a compact `statisticsJson` state containing its current-year quantity, financial and optional meter-reading statistics ([#361](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/361), [#967](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/967)).
+
 ### 0.5.3 (2026-07-28)
 * Power states can optionally ignore negative readings, so inverters which report a negative power while switched off no longer reduce the accumulated yield ([#466](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/466)).
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ This is a personal donation link for DutchmanNL and is not related to the ioBrok
 ## Changelog
 ### __WORK IN PROGRESS__
 * Each active source automatically exposes a compact `statisticsJson` state containing its current-year quantity, financial and optional meter-reading statistics ([#361](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/361), [#967](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/967)).
+* Monthly basic prices are no longer imported into the variable-cost accumulator and added a second time after a restart ([#1188](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/1188)).
 
 ### 0.5.3 (2026-07-28)
 * Power states can optionally ignore negative readings, so inverters which report a negative power while switched off no longer reduce the accumulated yield ([#466](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/466)).

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ SourceAnalytix is configured through the ioBroker custom settings of each source
 | Setting | Description |
 | --- | --- |
 | Enabled | Activates this source for the selected SourceAnalytix instance. |
-| Alias name | Optional readable name for the generated device. |
+| Alias | Optional display name for the generated device. It does not change the generated state ID. |
 | Select price definition | Mandatory category from the adapter's price definitions. |
 | Select Unit | Source unit. Leave on automatic detection when the source object has a correct supported unit. |
 | Calculate costs | Creates and updates cost or earnings states. |

--- a/admin/i18n/de.json
+++ b/admin/i18n/de.json
@@ -26,7 +26,7 @@
     "Active tariff price": "Aktiver Tarifpreis",
     "From": "Von",
     "ID": "ID",
-    "If no alias is set, name will be used": "Wenn kein Alias ​​festgelegt ist, wird der Name verwendet",
+    "Alias changes only the display name; the generated state ID remains unchanged": "Der Alias ändert nur den Anzeigenamen; die erzeugte Datenpunkt-ID bleibt unverändert",
     "Including basic rate": "Inklusive Grundpreis",
     "Invert selection": "Auswahl umkehren",
     "Last changed": "Letzte Änderung",

--- a/admin/i18n/en.json
+++ b/admin/i18n/en.json
@@ -26,7 +26,7 @@
     "Active tariff price": "Active tariff price",
     "From": "From",
     "ID": "ID",
-    "If no alias is set, name will be used": "If no alias is set, name will be used",
+    "Alias changes only the display name; the generated state ID remains unchanged": "Alias changes only the display name; the generated state ID remains unchanged",
     "Including basic rate": "Including basic rate",
     "Invert selection": "Invert selection",
     "Last changed": "Last changed",

--- a/admin/i18n/es.json
+++ b/admin/i18n/es.json
@@ -11,7 +11,7 @@
     "Current year": "Año corriente",
     "Description": "Descripción",
     "Enable device value reset detection": "Detección de restablecimiento del valor del dispositivo Habilitado",
-    "If no alias is set, name will be used": "Si no se establece un alias, se usará el nombre",
+    "Alias changes only the display name; the generated state ID remains unchanged": "El alias solo cambia el nombre mostrado; el ID del estado generado permanece sin cambios",
     "Including basic rate": "Incluyendo tarifa básica",
     "Meter reading at the beginning of the day": "Lectura del medidor al comienzo del día.",
     "Meter reading at the beginning of the month": "Lectura de contadores a principios de mes",

--- a/admin/i18n/fr.json
+++ b/admin/i18n/fr.json
@@ -11,7 +11,7 @@
     "Current year": "Année actuelle",
     "Description": "La description",
     "Enable device value reset detection": "Détection de réinitialisation de la valeur de l'appareil Activé",
-    "If no alias is set, name will be used": "Si aucun alias n'est défini, le nom sera utilisé",
+    "Alias changes only the display name; the generated state ID remains unchanged": "L'alias modifie uniquement le nom affiché ; l'ID d'état généré reste inchangé",
     "Including basic rate": "Y compris le tarif de base",
     "Meter reading at the beginning of the day": "Relevé du compteur en début de journée",
     "Meter reading at the beginning of the month": "Relevé du compteur au début du mois",

--- a/admin/i18n/it.json
+++ b/admin/i18n/it.json
@@ -11,7 +11,7 @@
     "Current year": "Anno corrente",
     "Description": "Descrizione",
     "Enable device value reset detection": "Rilevamento reset valore dispositivo Abilitato",
-    "If no alias is set, name will be used": "Se non viene impostato alcun alias, verrà utilizzato il nome",
+    "Alias changes only the display name; the generated state ID remains unchanged": "L'alias modifica solo il nome visualizzato; l'ID dello stato generato rimane invariato",
     "Including basic rate": "Inclusa tariffa base",
     "Meter reading at the beginning of the day": "Lettura del contatore all'inizio della giornata",
     "Meter reading at the beginning of the month": "Lettura del contatore all'inizio del mese",

--- a/admin/i18n/nl.json
+++ b/admin/i18n/nl.json
@@ -11,7 +11,7 @@
     "Current year": "Huidig jaar",
     "Description": "Omschrijving",
     "Enable device value reset detection": "Hersteldetectie apparaatwaarde Ingeschakeld",
-    "If no alias is set, name will be used": "Als er geen alias is ingesteld, wordt de naam gebruikt",
+    "Alias changes only the display name; the generated state ID remains unchanged": "De alias wijzigt alleen de weergavenaam; de gegenereerde status-ID blijft ongewijzigd",
     "Including basic rate": "Inclusief basistarief",
     "Meter reading at the beginning of the day": "Meterstand aan het begin van de dag",
     "Meter reading at the beginning of the month": "Meterstand aan het begin van de maand",

--- a/admin/i18n/pl.json
+++ b/admin/i18n/pl.json
@@ -11,7 +11,7 @@
     "Current year": "Rok bieżący",
     "Description": "Opis",
     "Enable device value reset detection": "Wykrywanie resetowania wartości urządzenia Włączone",
-    "If no alias is set, name will be used": "Jeśli nie zostanie ustawiony żaden alias, zostanie użyta nazwa",
+    "Alias changes only the display name; the generated state ID remains unchanged": "Alias zmienia tylko nazwę wyświetlaną; identyfikator wygenerowanego stanu pozostaje bez zmian",
     "Including basic rate": "W tym stawka podstawowa",
     "Meter reading at the beginning of the day": "Odczyt licznika na początku dnia",
     "Meter reading at the beginning of the month": "Odczyt licznika na początku miesiąca",

--- a/admin/i18n/pt.json
+++ b/admin/i18n/pt.json
@@ -11,7 +11,7 @@
     "Current year": "Ano atual",
     "Description": "Descrição",
     "Enable device value reset detection": "Detecção de redefinição do valor do dispositivo Ativado",
-    "If no alias is set, name will be used": "Se nenhum alias for definido, o nome será usado",
+    "Alias changes only the display name; the generated state ID remains unchanged": "O alias altera apenas o nome exibido; o ID do estado gerado permanece inalterado",
     "Including basic rate": "Incluindo taxa básica",
     "Meter reading at the beginning of the day": "Leitura do medidor no início do dia",
     "Meter reading at the beginning of the month": "Leitura do medidor no início do mês",

--- a/admin/i18n/ru.json
+++ b/admin/i18n/ru.json
@@ -11,7 +11,7 @@
     "Current year": "Текущий год",
     "Description": "Описание",
     "Enable device value reset detection": "Обнаружение сброса значения устройства Включено",
-    "If no alias is set, name will be used": "Если псевдоним не задан, будет использоваться имя",
+    "Alias changes only the display name; the generated state ID remains unchanged": "Псевдоним изменяет только отображаемое имя; идентификатор созданного состояния остается неизменным",
     "Including basic rate": "Включая базовую ставку",
     "Meter reading at the beginning of the day": "Показания счетчика в начале дня",
     "Meter reading at the beginning of the month": "Показания счетчика в начале месяца",

--- a/admin/i18n/uk.json
+++ b/admin/i18n/uk.json
@@ -11,7 +11,7 @@
     "Current year": "Current year",
     "Description": "Description",
     "Enable device value reset detection": "Device value reset detection Enabled",
-    "If no alias is set, name will be used": "Якщо псевдонім не задано, буде використано назву",
+    "Alias changes only the display name; the generated state ID remains unchanged": "Псевдонім змінює лише відображуване ім'я; ідентифікатор створеного стану залишається незмінним",
     "Including basic rate": "Including basic rate",
     "Meter reading at the beginning of the day": "Показання лічильника на початок дня",
     "Meter reading at the beginning of the month": "Показання лічильника на початок місяця",

--- a/admin/i18n/zh-cn.json
+++ b/admin/i18n/zh-cn.json
@@ -11,7 +11,7 @@
     "Current year": "今年",
     "Description": "描述",
     "Enable device value reset detection": "软元件值复位检测 启用",
-    "If no alias is set, name will be used": "如果未设置别名，将使用名称",
+    "Alias changes only the display name; the generated state ID remains unchanged": "别名仅更改显示名称；生成的状态 ID 保持不变",
     "Including basic rate": "含基本费率",
     "Meter reading at the beginning of the day": "一天开始时抄表",
     "Meter reading at the beginning of the month": "月初抄表",

--- a/admin/jsonCustom.json
+++ b/admin/jsonCustom.json
@@ -11,8 +11,8 @@
     },
     "alias": {
       "type": "text",
-      "label": "Alias name",
-      "help": "If no alias is set, name will be used",
+      "label": "Alias",
+      "help": "Alias changes only the display name; the generated state ID remains unchanged",
       "xs": 12,
       "sm": 12,
       "md": 5,

--- a/lib/calculation.js
+++ b/lib/calculation.js
@@ -298,6 +298,70 @@ function calculateBasicPriceTotals(monthlyPrice, date) {
 }
 
 /**
+ * Calculate variable cost totals from one cumulative reading and its period starts.
+ * @param {number | string} reading - Current cumulative reading
+ * @param {object} startValues - Period start readings
+ * @param {number | string} unitPrice - Price per consumed unit
+ * @returns {{priceDay: number, priceWeek: number, priceMonth: number, priceQuarter: number, priceYear: number}} Variable costs without a basic price
+ */
+function calculateVariablePriceTotals(reading, startValues, unitPrice) {
+	const parseNumber = value => {
+		if (value === null || value === undefined) return null;
+		if (typeof value === 'string' && value.trim() === '') return null;
+		const parsed = typeof value === 'string' ? Number(value.trim().replace(',', '.')) : Number(value);
+		return Number.isFinite(parsed) ? parsed : null;
+	};
+	const readingNumber = parseNumber(reading);
+	const unitPriceNumber = parseNumber(unitPrice);
+	const safeReading = readingNumber === null ? 0 : readingNumber;
+	const safeUnitPrice = unitPriceNumber === null ? 0 : unitPriceNumber;
+	const costSince = key => {
+		const start = parseNumber(startValues && startValues[key]);
+		return safeUnitPrice * (safeReading - (start === null ? safeReading : start));
+	};
+
+	return {
+		priceDay: costSince('start_day'),
+		priceWeek: costSince('start_week'),
+		priceMonth: costSince('start_month'),
+		priceQuarter: costSince('start_quarter'),
+		priceYear: costSince('start_year'),
+	};
+}
+
+/**
+ * Convert legacy accumulated costs to variable-only totals.
+ * @param {object} legacyTotals - Totals stored by schema version 1
+ * @param {object} basicTotals - Basic-price shares for the same periods
+ * @param {object} fallbackTotals - Totals rebuilt from fixed price and period starts
+ * @param {string} priceSource - static, state or selector
+ * @param {number} priceHistoryLength - Number of known historical prices
+ * @param {boolean} hasBasicPrice - Whether the source includes a monthly basic price
+ * @returns {object} Variable-only cost totals
+ */
+function migrateLegacyVariableCostTotals(legacyTotals, basicTotals, fallbackTotals, priceSource, priceHistoryLength, hasBasicPrice) {
+	if (priceSource === 'static' && priceHistoryLength <= 1) return {...fallbackTotals};
+	if (!hasBasicPrice) return {...legacyTotals};
+
+	const migratedTotals = {};
+	for (const key of Object.keys(legacyTotals)) {
+		const legacyValue = Number(legacyTotals[key]);
+		const basicValue = Number(basicTotals[key]);
+		migratedTotals[key] = (Number.isFinite(legacyValue) ? legacyValue : 0) - (Number.isFinite(basicValue) ? basicValue : 0);
+	}
+
+	const fallbackValues = Object.values(fallbackTotals).map(Number).filter(Number.isFinite);
+	if (fallbackValues.length === 0 || fallbackValues.every(value => value === 0)) return {...legacyTotals};
+	const distanceFromFallback = totals => Object.keys(legacyTotals).reduce((distance, key) => {
+		const total = Number(totals[key]);
+		const fallback = Number(fallbackTotals[key]);
+		return Number.isFinite(total) && Number.isFinite(fallback) ? distance + Math.abs(total - fallback) : distance;
+	}, 0);
+
+	return distanceFromFallback(migratedTotals) < distanceFromFallback(legacyTotals) ? migratedTotals : {...legacyTotals};
+}
+
+/**
  * Normalize a raw power reading before it is integrated over an interval.
  * Some inverters report a strongly negative power while they are switched off.
  * Such a reading is clamped to zero instead of being dropped, so the interval
@@ -342,12 +406,14 @@ function calculatePowerEnergy(previousPower, currentPower, previousTimestamp, cu
 module.exports = {
 	buildUnitConfig,
 	calculateBasicPriceTotals,
+	calculateVariablePriceTotals,
 	calculatePowerEnergy,
 	classifyCumulativeReading,
 	convertUnitValue,
 	getCurrentYearPeriodStateDefinitions,
 	getPeriodChanges,
 	initializePeriodStartValues,
+	migrateLegacyVariableCostTotals,
 	normalizePeriodSnapshot,
 	normalizePowerReading,
 	resolveCumulativeReading,

--- a/lib/dynamic-pricing.js
+++ b/lib/dynamic-pricing.js
@@ -8,7 +8,9 @@ function parsePriceValue(value) {
 	if (value === null || value === undefined || value === '') return null;
 	if (typeof value === 'number') return Number.isFinite(value) ? value : null;
 	if (typeof value === 'string') {
-		const parsedValue = Number(value.trim().replace(',', '.'));
+		const normalizedValue = value.trim();
+		if (normalizedValue === '') return null;
+		const parsedValue = Number(normalizedValue.replace(',', '.'));
 		return Number.isFinite(parsedValue) ? parsedValue : null;
 	}
 	return null;
@@ -148,7 +150,9 @@ function calculatePriceDelta(history, delta, startTimestamp, endTimestamp, fallb
  * @returns {{version: number, priceDefinition: string, lastReading: number, lastTs: number, totals: {priceDay: number, priceWeek: number, priceMonth: number, priceQuarter: number, priceYear: number}} | null} Validated dynamic cost memory
  */
 function normalizeDynamicCostMemory(memory) {
-	if (!memory || memory.version !== 1 || typeof memory.priceDefinition !== 'string') return null;
+	if (!memory || typeof memory.priceDefinition !== 'string') return null;
+	const version = Number(memory.version);
+	if (![1, 2].includes(version)) return null;
 
 	const lastReading = parsePriceValue(memory.lastReading);
 	const lastTs = Number(memory.lastTs);
@@ -163,7 +167,7 @@ function normalizeDynamicCostMemory(memory) {
 	if (priceDay === null || priceWeek === null || priceMonth === null || priceQuarter === null || priceYear === null) return null;
 
 	return {
-		version: 1,
+		version,
 		priceDefinition: memory.priceDefinition,
 		lastReading,
 		lastTs,

--- a/lib/statistics-json.js
+++ b/lib/statistics-json.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const BASIC_PERIODS = {
+	'01_currentDay': ['current', 'day'],
+	'02_currentWeek': ['current', 'week'],
+	'03_currentMonth': ['current', 'month'],
+	'04_currentQuarter': ['current', 'quarter'],
+	'05_currentYear': ['current', 'year'],
+	'01_previousDay': ['previous', 'day'],
+	'02_previousWeek': ['previous', 'week'],
+	'03_previousMonth': ['previous', 'month'],
+	'04_previousQuarter': ['previous', 'quarter'],
+	'05_previousYear': ['previous', 'year'],
+};
+
+/**
+ * @param {boolean} enabled - Whether the section is enabled
+ * @param {object} options - Period collection settings
+ * @returns {object|null} Empty statistics section
+ */
+function createValueSection(enabled, options) {
+	if (!enabled) return null;
+	return {
+		current: {
+			day: null,
+			week: null,
+			month: null,
+			quarter: null,
+			year: null,
+		},
+		previous: options.previous ? {
+			day: null,
+			week: null,
+			month: null,
+			quarter: null,
+			year: null,
+		} : null,
+		periods: {
+			weekdays: options.days ? {} : null,
+			previousWeekdays: options.days && options.previous ? {} : null,
+			weeks: options.weeks ? {} : null,
+			months: options.months ? {} : null,
+			quarters: options.quarters ? {} : null,
+		},
+	};
+}
+
+/**
+ * Create an empty, stable statistics JSON structure.
+ * @param {object} options - Source and adapter configuration
+ * @returns {object} Statistics snapshot
+ */
+function createStatisticsSnapshot(options) {
+	const periods = {
+		days: options.days === true,
+		weeks: options.weeks === true,
+		months: options.months === true,
+		quarters: options.quarters === true,
+		previous: options.previous === true,
+	};
+	const quantityValues = createValueSection(options.consumption === true, periods);
+	const financialValues = createValueSection(options.costs === true, periods);
+	const meterReadings = createValueSection(options.meterValues === true, periods);
+	if (meterReadings) {
+		meterReadings.current = null;
+	}
+	const quantity = quantityValues ? {
+		type: options.quantityType,
+		...quantityValues,
+	} : null;
+	const financial = financialValues ? {
+		type: options.financialType,
+		currency: options.currency,
+		...financialValues,
+	} : null;
+
+	return {
+		schemaVersion: 1,
+		year: options.year,
+		source: {
+			id: options.sourceId,
+			name: normalizeName(options.sourceName),
+			unit: options.unit,
+		},
+		quantity,
+		financial,
+		meterReadings,
+	};
+}
+
+/**
+ * @param {unknown} name - ioBroker common.name value
+ * @returns {string} Display name
+ */
+function normalizeName(name) {
+	if (typeof name === 'string') return name;
+	if (name && typeof name === 'object') {
+		const translatedName = Reflect.get(name, 'en') || Reflect.get(name, 'de')
+			|| Object.values(name).find(value => typeof value === 'string');
+		return typeof translatedName === 'string' ? translatedName : '';
+	}
+	return '';
+}
+
+/**
+ * @param {unknown} value - State value
+ * @returns {number|null} Numeric value
+ */
+function normalizeValue(value) {
+	if (value === null || value === undefined || value === '') return null;
+	const number = Number(value);
+	return Number.isFinite(number) ? number : null;
+}
+
+/**
+ * @param {string} collection - Internal collection name
+ * @param {string} stateName - Internal state name
+ * @returns {string|null} Language-neutral period key
+ */
+function getPeriodKey(collection, stateName) {
+	if (collection === 'currentWeek' || collection === 'previousWeek') {
+		const match = stateName.match(/^0?([1-7])_/);
+		return match ? match[1] : null;
+	}
+	if (collection === 'weeks') {
+		const match = stateName.match(/^(\d{1,2})/);
+		return match ? match[1].padStart(2, '0') : null;
+	}
+	if (collection === 'months') {
+		const match = stateName.match(/^(\d{1,2})/);
+		return match ? match[1].padStart(2, '0') : null;
+	}
+	if (collection === 'quarters') {
+		const match = stateName.match(/^Q?([1-4])$/);
+		return match ? match[1] : null;
+	}
+	return null;
+}
+
+/**
+ * Apply one existing SourceAnalytix state to a statistics snapshot.
+ * @param {object} snapshot - Mutable statistics snapshot
+ * @param {string} relativePath - Path below the source device
+ * @param {unknown} value - State value
+ * @returns {boolean} Whether the path belongs to the snapshot
+ */
+function applyStatisticsState(snapshot, relativePath, value) {
+	const normalizedValue = normalizeValue(value);
+	if (relativePath === 'cumulativeReading') {
+		if (!snapshot.meterReadings) return false;
+		snapshot.meterReadings.current = normalizedValue;
+		return true;
+	}
+
+	const match = relativePath.match(/^currentYear\.(consumed|delivered|costs|earnings|meterReadings)\.(.+)$/);
+	if (!match) return false;
+
+	const [, category, suffix] = match;
+	const section = category === 'consumed' || category === 'delivered'
+		? snapshot.quantity
+		: category === 'costs' || category === 'earnings'
+			? snapshot.financial
+			: snapshot.meterReadings;
+	if (!section) return false;
+	if (category !== 'meterReadings' && section.type !== category) return false;
+
+	const basicPeriod = BASIC_PERIODS[suffix];
+	if (basicPeriod) {
+		const [group, period] = basicPeriod;
+		if (group === 'current' && category === 'meterReadings') return false;
+		if (!section[group]) return false;
+		section[group][period] = normalizedValue;
+		return true;
+	}
+
+	const periodMatch = suffix.match(/^(currentWeek|previousWeek|weeks|months|quarters)\.(.+)$/);
+	if (!periodMatch) return false;
+	const [, collection, stateName] = periodMatch;
+	const targetName = collection === 'currentWeek'
+		? 'weekdays'
+		: collection === 'previousWeek'
+			? 'previousWeekdays'
+			: collection;
+	const target = section.periods[targetName];
+	const key = getPeriodKey(collection, stateName);
+	if (!target || !key) return false;
+	target[key] = normalizedValue;
+	return true;
+}
+
+/**
+ * @param {object} snapshot - Statistics snapshot
+ * @returns {string} Serialized state value
+ */
+function serializeStatisticsSnapshot(snapshot) {
+	return JSON.stringify(snapshot);
+}
+
+module.exports = {
+	applyStatisticsState,
+	createStatisticsSnapshot,
+	serializeStatisticsSnapshot,
+};

--- a/main.js
+++ b/main.js
@@ -1256,7 +1256,7 @@ class Sourceanalytix extends utils.Adapter {
 				this.activeStates[stateID] = {
 					firstActivation: useUnit !== 'W' && valueAtDeviceReset === null,
 					stateDetails: {
-						alias: customData.alias !== '' ? customData.alias : '',
+						alias: typeof customData.alias === 'string' ? customData.alias.trim() : '',
 						averagePowerValues: customData.averagePowerValues === true,
 						basicRate: customData.basicRate === true,
 						consumption: customData.consumption,
@@ -1265,7 +1265,7 @@ class Sourceanalytix extends utils.Adapter {
 						financialCategory: stateType,
 						headCategory: stateType === 'earnings' ? 'delivered' : 'consumed',
 						meter_values: customData.meter_values,
-						name: stateInfo.common.name !== '' ? customData.alias : 'No name known, please provide alias',
+						name: commonData.name || 'No name known, please provide alias',
 						stateType: customData.selectedPrice,
 						stateUnit: useUnit,
 						useUnit: selectedPriceConfig.unitType,

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const adapterHelpers = require('iobroker-adapter-helpers'); // Lib used for Unit
 const schedule = require('cron').CronJob; // Cron Scheduler
 const calculation = require('./lib/calculation');
 const dynamicPricing = require('./lib/dynamic-pricing');
+const statisticsJson = require('./lib/statistics-json');
 
 // Sentry error reporting, disable when testing alpha source code locally!
 const disableSentry = false;
@@ -56,6 +57,9 @@ class Sourceanalytix extends utils.Adapter {
 		this.priceHistories = {}; // Price definition category -> ordered price history
 		this.validStates = {}; // Array of all created states
 		this.visWidgetJson ={}; // Array containing all calculation values to use in vis widget
+		this.statisticsJsonSnapshots = {};
+		this.statisticsJsonTimers = {};
+		this.statisticsJsonLastValues = {};
 	}
 
 	/**
@@ -787,6 +791,16 @@ class Sourceanalytix extends utils.Adapter {
 			val: calculationRounded.priceYear,
 			ack: true
 		});
+		const currentValues = [
+			['01_currentDay', calculationRounded.priceDay],
+			['02_currentWeek', calculationRounded.priceWeek],
+			['03_currentMonth', calculationRounded.priceMonth],
+			['04_currentQuarter', calculationRounded.priceQuarter],
+			['05_currentYear', calculationRounded.priceYear],
+		];
+		for (const [state, value] of currentValues) {
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.financialCategory}.${state}`, value);
+		}
 
 		if (this.config.store_weeks || this.config.store_months || this.config.store_quarters) {
 			await this.setStateChangedAsync(`${this.namespace}.${stateDetails.deviceName}.${actualDate.year}.${stateDetails.financialCategory}Cumulative`, {
@@ -800,24 +814,28 @@ class Sourceanalytix extends utils.Adapter {
 				val: calculationRounded.priceDay,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.financialCategory}.currentWeek.${weekdays[date.getDay()]}`, calculationRounded.priceDay);
 		}
 		if (this.config.currentYearWeek) {
 			await this.setStateChangedAsync(`${stateName}.weeks.${actualDate.week}`, {
 				val: calculationRounded.priceWeek,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.financialCategory}.weeks.${actualDate.week}`, calculationRounded.priceWeek);
 		}
 		if (this.config.currentYearMonth) {
 			await this.setStateChangedAsync(`${stateName}.months.${actualDate.month}`, {
 				val: calculationRounded.priceMonth,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.financialCategory}.months.${actualDate.month}`, calculationRounded.priceMonth);
 		}
 		if (this.config.currentYearQuarter) {
 			await this.setStateChangedAsync(`${stateName}.quarters.Q${actualDate.quarter}`, {
 				val: calculationRounded.priceQuarter,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.financialCategory}.quarters.Q${actualDate.quarter}`, calculationRounded.priceQuarter);
 		}
 
 		stateName = `${this.namespace}.${stateDetails.deviceName}.${actualDate.year}.${stateDetails.financialCategory}`;
@@ -854,6 +872,7 @@ class Sourceanalytix extends utils.Adapter {
 		];
 		for (const [state, value] of currentValues) {
 			await this.setStateChangedAsync(`${stateName}.${state}`, {val: value, ack: true});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.headCategory}.${state}`, value);
 		}
 
 		if (this.config.store_weeks || this.config.store_months || this.config.store_quarters) {
@@ -867,30 +886,180 @@ class Sourceanalytix extends utils.Adapter {
 				val: calculationRounded.consumedDay,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.headCategory}.currentWeek.${weekdays[date.getDay()]}`, calculationRounded.consumedDay);
 		}
 		if (this.config.currentYearWeek) {
 			await this.setStateChangedAsync(`${stateName}.weeks.${actualDate.week}`, {
 				val: calculationRounded.consumedWeek,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.headCategory}.weeks.${actualDate.week}`, calculationRounded.consumedWeek);
 		}
 		if (this.config.currentYearMonth) {
 			await this.setStateChangedAsync(`${stateName}.months.${actualDate.month}`, {
 				val: calculationRounded.consumedMonth,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.headCategory}.months.${actualDate.month}`, calculationRounded.consumedMonth);
 		}
 		if (this.config.currentYearQuarter) {
 			await this.setStateChangedAsync(`${stateName}.quarters.Q${actualDate.quarter}`, {
 				val: calculationRounded.consumedQuarter,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, `currentYear.${stateDetails.headCategory}.quarters.Q${actualDate.quarter}`, calculationRounded.consumedQuarter);
 		}
 
 		stateName = `${this.namespace}.${stateDetails.deviceName}.${actualDate.year}.${stateDetails.headCategory}`;
 		if (storeSettings.storeWeeks) await this.setStateChangedAsync(`${stateName}.weeks.${actualDate.week}`, {val: calculationRounded.consumedWeek, ack: true});
 		if (storeSettings.storeMonths) await this.setStateChangedAsync(`${stateName}.months.${actualDate.month}`, {val: calculationRounded.consumedMonth, ack: true});
 		if (storeSettings.storeQuarters) await this.setStateChangedAsync(`${stateName}.quarters.Q${actualDate.quarter}`, {val: calculationRounded.consumedQuarter, ack: true});
+	}
+
+	/**
+	 * @param {string} stateID - Source state ID
+	 * @returns {object|null} Empty snapshot for the active source
+	 */
+	createStatisticsJsonSnapshot(stateID) {
+		const activeState = this.activeStates[stateID];
+		if (!activeState || !activeState.stateDetails) return null;
+		const details = activeState.stateDetails;
+		return statisticsJson.createStatisticsSnapshot({
+			year: actualDate.year,
+			sourceId: stateID,
+			sourceName: details.alias || details.name,
+			unit: details.useUnit,
+			quantityType: details.headCategory,
+			financialType: details.financialCategory,
+			currency: useCurrency,
+			consumption: details.consumption,
+			costs: details.costs,
+			meterValues: details.meter_values,
+			days: this.config.currentYearDays,
+			weeks: this.config.currentYearWeek,
+			months: this.config.currentYearMonth,
+			quarters: this.config.currentYearQuarter,
+			previous: this.config.currentYearPrevious,
+		});
+	}
+
+	/**
+	 * @param {string} stateID - Source state ID
+	 * @returns {string|null} Local JSON state ID
+	 */
+	getStatisticsJsonStateName(stateID) {
+		const activeState = this.activeStates[stateID];
+		return activeState && activeState.stateDetails
+			? `${activeState.stateDetails.deviceName}.statisticsJson`
+			: null;
+	}
+
+	/**
+	 * @param {string} stateID - Source state ID
+	 */
+	async ensureStatisticsJsonState(stateID) {
+		const stateName = this.getStatisticsJsonStateName(stateID);
+		if (!stateName) return;
+		await this.extendObjectAsync(stateName, {
+			type: 'state',
+			common: {
+				name: 'Statistics JSON',
+				type: 'string',
+				role: 'json',
+				read: true,
+				write: false,
+				def: '',
+			},
+			native: {
+				sourceState: stateID,
+				schemaVersion: 1,
+			},
+		});
+	}
+
+	/**
+	 * Rebuild the cache from existing current-year states.
+	 * @param {string} stateID - Source state ID
+	 */
+	async refreshStatisticsJson(stateID) {
+		const snapshot = this.createStatisticsJsonSnapshot(stateID);
+		const stateName = this.getStatisticsJsonStateName(stateID);
+		if (!snapshot || !stateName) return;
+
+		const deviceName = this.activeStates[stateID].stateDetails.deviceName;
+		const existingStates = await this.getStatesAsync(`${deviceName}.*`);
+		for (const [id, state] of Object.entries(existingStates || {})) {
+			if (!state) continue;
+			const localPrefix = `${deviceName}.`;
+			const fullPrefix = `${this.namespace}.${localPrefix}`;
+			const relativePath = id.startsWith(fullPrefix)
+				? id.slice(fullPrefix.length)
+				: id.startsWith(localPrefix)
+					? id.slice(localPrefix.length)
+					: null;
+			if (relativePath) statisticsJson.applyStatisticsState(snapshot, relativePath, state.val);
+		}
+
+		const existingJson = await this.getStateAsync(stateName);
+		this.statisticsJsonLastValues[stateID] = existingJson && typeof existingJson.val === 'string'
+			? existingJson.val
+			: null;
+		this.statisticsJsonSnapshots[stateID] = snapshot;
+		this.scheduleStatisticsJsonWrite(stateID);
+	}
+
+	/**
+	 * @param {string} stateID - Source state ID
+	 * @param {string} relativePath - State path below the source device
+	 * @param {unknown} value - Calculated value
+	 */
+	recordStatisticsValue(stateID, relativePath, value) {
+		const snapshot = this.statisticsJsonSnapshots[stateID];
+		if (!snapshot) return;
+		if (statisticsJson.applyStatisticsState(snapshot, relativePath, value)) {
+			this.scheduleStatisticsJsonWrite(stateID);
+		}
+	}
+
+	/**
+	 * @param {string} stateID - Source state ID
+	 */
+	scheduleStatisticsJsonWrite(stateID) {
+		if (this.statisticsJsonTimers[stateID]) return;
+		this.statisticsJsonTimers[stateID] = this.setTimeout(() => {
+			delete this.statisticsJsonTimers[stateID];
+			void this.flushStatisticsJson(stateID);
+		}, 300);
+	}
+
+	/**
+	 * @param {string} stateID - Source state ID
+	 */
+	async flushStatisticsJson(stateID) {
+		try {
+			const snapshot = this.statisticsJsonSnapshots[stateID];
+			const stateName = this.getStatisticsJsonStateName(stateID);
+			if (!snapshot || !stateName || !this.activeStates[stateID]) return;
+			const serialized = statisticsJson.serializeStatisticsSnapshot(snapshot);
+			if (serialized === this.statisticsJsonLastValues[stateID]) return;
+			await this.setStateChangedAsync(stateName, {val: serialized, ack: true});
+			this.statisticsJsonLastValues[stateID] = serialized;
+		} catch (error) {
+			this.errorHandling(`[flushStatisticsJson] ${stateID}`, error);
+		}
+	}
+
+	/**
+	 * Stop updates while retaining the last persisted JSON state.
+	 * @param {string} stateID - Source state ID
+	 */
+	stopStatisticsJsonUpdates(stateID) {
+		if (this.statisticsJsonTimers[stateID]) {
+			this.clearTimeout(this.statisticsJsonTimers[stateID]);
+			delete this.statisticsJsonTimers[stateID];
+		}
+		delete this.statisticsJsonSnapshots[stateID];
+		delete this.statisticsJsonLastValues[stateID];
 	}
 
 	//ToDo 0.5: Implement cleanup for unused states
@@ -997,6 +1166,7 @@ class Sourceanalytix extends utils.Adapter {
 				stateInfo = await this.getForeignObjectAsync(stateID);
 				if (!stateInfo) {
 					this.log.error(`Can't get information for ${stateID}, state will be ignored`);
+					this.stopStatisticsJsonUpdates(stateID);
 					delete this.activeStates[stateID];
 					this.unsubscribeForeignStates(stateID);
 					initError = true;
@@ -1004,6 +1174,7 @@ class Sourceanalytix extends utils.Adapter {
 				}
 			} catch (error) {
 				this.log.error(`${stateID} is incorrectly correctly formatted, ${JSON.stringify(error)}`);
+				this.stopStatisticsJsonUpdates(stateID);
 				delete this.activeStates[stateID];
 				this.unsubscribeForeignStates(stateID);
 				initError = true;
@@ -1071,6 +1242,7 @@ class Sourceanalytix extends utils.Adapter {
 				// In case of one of above checks fails, abort procedure
 				if (initError){
 					this.log.error(`Cannot handle calculations for ${stateID}, check log messages and adjust settings!`);
+					this.stopStatisticsJsonUpdates(stateID);
 					delete this.activeStates[stateID];
 					this.unsubscribeForeignStates(stateID);
 					return false;
@@ -1231,6 +1403,9 @@ class Sourceanalytix extends utils.Adapter {
 			const stateName = 'cumulativeReading';
 			await this.doLocalStateCreate(stateID, stateName, 'Cumulative Reading', true);
 
+			await this.ensureStatisticsJsonState(stateID);
+			await this.refreshStatisticsJson(stateID);
+
 			// Recover a calendar reset missed while the adapter was stopped.
 			await this.processPeriodRollover(stateID, new Date());
 
@@ -1296,6 +1471,7 @@ class Sourceanalytix extends utils.Adapter {
 					}
 
 				} else if (this.activeStates[stateID]) {
+					this.stopStatisticsJsonUpdates(stateID);
 					delete this.activeStates[stateID];
 					this.log.info(`Disabled SourceAnalytix for : ${stateID}`);
 					this.log.debug(`Active state array after deactivation of ${stateID} : ${JSON.stringify(this.activeStates)}`);
@@ -1303,6 +1479,7 @@ class Sourceanalytix extends utils.Adapter {
 				}
 
 			} else if (this.activeStates[stateID]) {
+				this.stopStatisticsJsonUpdates(stateID);
 				delete this.activeStates[stateID];
 				delete previousCalculationRounded[stateID];
 				this.unsubscribeForeignStates(stateID);
@@ -1681,6 +1858,7 @@ class Sourceanalytix extends utils.Adapter {
 		});
 		await this.writeCurrentPeriodValuesAfterReset(stateID, Number(reading), date);
 		await this.persistPeriodMemory(stateID, currentPeriods);
+		await this.refreshStatisticsJson(stateID);
 		return true;
 	}
 
@@ -2107,6 +2285,7 @@ class Sourceanalytix extends utils.Adapter {
 				val: reading,
 				ack: true
 			});
+			this.recordStatisticsValue(stateID, 'cumulativeReading', reading);
 
 			// Write current reading at year statistics
 			if (this.config.store_weeks || this.config.store_months || 	this.config.store_quarters){
@@ -2149,24 +2328,28 @@ class Sourceanalytix extends utils.Adapter {
 							val: readingRounded,
 							ack: true
 						});
+						this.recordStatisticsValue(stateID, `currentYear.meterReadings.currentWeek.${weekdays[date.getDay()]}`, readingRounded);
 					}
 					if (this.config.currentYearWeek) {
 						await this.setStateChangedAsync(`${stateName}.weeks.${actualDate.week}`, {
 							val: readingRounded,
 							ack: true
 						});
+						this.recordStatisticsValue(stateID, `currentYear.meterReadings.weeks.${actualDate.week}`, readingRounded);
 					}
 					if (this.config.currentYearMonth) {
 						await this.setStateChangedAsync(`${stateName}.months.${actualDate.month}`, {
 							val: readingRounded,
 							ack: true
 						});
+						this.recordStatisticsValue(stateID, `currentYear.meterReadings.months.${actualDate.month}`, readingRounded);
 					}
 					if (this.config.currentYearQuarter) {
 						await this.setStateChangedAsync(`${stateName}.quarters.Q${actualDate.quarter}`, {
 							val: readingRounded,
 							ack: true
 						});
+						this.recordStatisticsValue(stateID, `currentYear.meterReadings.quarters.Q${actualDate.quarter}`, readingRounded);
 					}
 					stateName = `${`${this.namespace}.${stateDetails.deviceName}`}.${actualDate.year}.meterReadings`;
 					if (storeSettings.storeWeeks) await this.setStateChangedAsync(`${stateName}.weeks.${actualDate.week}`, {
@@ -2517,6 +2700,10 @@ class Sourceanalytix extends utils.Adapter {
 	 */
 	onUnload(callback) {
 		try {
+			for (const timer of Object.values(this.statisticsJsonTimers)) {
+				this.clearTimeout(timer);
+			}
+			this.statisticsJsonTimers = {};
 			this.log.info(`SourceAnalytix stopped, now you have to calculate by yourself :'( ...`);
 			callback();
 		} catch {

--- a/main.js
+++ b/main.js
@@ -489,28 +489,26 @@ class Sourceanalytix extends utils.Adapter {
 	 * @returns {object} Cost totals calculated with the fallback price
 	 */
 	getFallbackDynamicCostTotals(reading, calcValues, unitPrice) {
-		return {
-			priceDay: unitPrice * (reading - this.getNumberOrDefault(calcValues.start_day, reading)),
-			priceWeek: unitPrice * (reading - this.getNumberOrDefault(calcValues.start_week, reading)),
-			priceMonth: unitPrice * (reading - this.getNumberOrDefault(calcValues.start_month, reading)),
-			priceQuarter: unitPrice * (reading - this.getNumberOrDefault(calcValues.start_quarter, reading)),
-			priceYear: unitPrice * (reading - this.getNumberOrDefault(calcValues.start_year, reading)),
-		};
+		return calculation.calculateVariablePriceTotals(reading, calcValues, unitPrice);
 	}
 
 	/**
 	 * @param {string} stateID - Local ioBroker state ID
-	 * @param {number} fallback - Fallback value
+	 * @param {number} fallback - Fallback variable cost
+	 * @param {number} basicPrice - Basic-price share already included in the state
 	 * @returns {Promise<number>} Stored cost value or fallback
 	 */
-	async readCostStateOrFallback(stateID, fallback) {
+	async readVariableCostStateOrFallback(stateID, fallback, basicPrice) {
 		try {
 			const state = await this.getStateAsync(stateID);
 			const stateValue = state ? this.parsePriceValue(state.val) : null;
-			return stateValue === null ? fallback : stateValue;
+			if (stateValue === null) return fallback;
+			// Newly created ioBroker states use 0 before the first calculation.
+			if (stateValue === 0) return fallback;
+			return stateValue - basicPrice;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			this.log.debug(`[readCostStateOrFallback] Could not read ${stateID}, using fallback ${fallback}: ${message}`);
+			this.log.debug(`[readVariableCostStateOrFallback] Could not read ${stateID}, using fallback ${fallback}: ${message}`);
 			return fallback;
 		}
 	}
@@ -572,7 +570,7 @@ class Sourceanalytix extends utils.Adapter {
 
 		try {
 			const parsedMemory = JSON.parse(memoryState.val.toString());
-			const memory = dynamicPricing.normalizeDynamicCostMemory(parsedMemory);
+			let memory = dynamicPricing.normalizeDynamicCostMemory(parsedMemory);
 			if (!memory) {
 				this.log.warn(`[loadDynamicCostMemory] Ignoring invalid calculation memory for ${stateID}`);
 				return null;
@@ -582,6 +580,10 @@ class Sourceanalytix extends utils.Adapter {
 				this.log.info(`[loadDynamicCostMemory] Ignoring calculation memory for ${stateID} because price definition changed from ${memory.priceDefinition} to ${priceDefinition}`);
 				return null;
 			}
+			if (memory.version === 1) {
+				memory = await this.migrateLegacyDynamicCostMemory(stateID, memory);
+			}
+			if (!memory) return null;
 			this.log.info(`Restored precise dynamic cost memory for ${stateID} from ${new Date(memory.lastTs).toISOString()}`);
 			this.log.debug(`[loadDynamicCostMemory] Restored precise dynamic costs for ${stateID}: ${JSON.stringify(memory)}`);
 			return memory;
@@ -593,6 +595,35 @@ class Sourceanalytix extends utils.Adapter {
 	}
 
 	/**
+	 * Version 1 could initialize its accumulator from visible costs which already
+	 * included the monthly basic price. Version 2 always stores variable costs.
+	 * @param {string} stateID - Source state ID
+	 * @param {object} memory - Valid version 1 memory
+	 * @returns {Promise<object>} Migrated version 2 memory
+	 */
+	async migrateLegacyDynamicCostMemory(stateID, memory) {
+		const activeState = this.activeStates[stateID];
+		const priceHistory = this.priceHistories[activeState.stateDetails.stateType] || [];
+		const unitPrice = this.getNumberOrDefault(activeState.prices.unitPrice, 0);
+		const fallbackTotals = this.getFallbackDynamicCostTotals(memory.lastReading, activeState.calcValues, unitPrice);
+		const monthlyPrice = activeState.stateDetails.basicRate ? this.getNumberOrDefault(activeState.prices.basicPrice, 0) : 0;
+		const basicTotals = calculation.calculateBasicPriceTotals(monthlyPrice, new Date(memory.lastTs));
+		const totals = calculation.migrateLegacyVariableCostTotals(
+			memory.totals,
+			basicTotals,
+			fallbackTotals,
+			activeState.prices.priceSource,
+			priceHistory.length,
+			activeState.stateDetails.basicRate,
+		);
+
+		const migratedMemory = {...memory, version: 2, totals};
+		await this.persistDynamicCostMemory(stateID, migratedMemory);
+		this.log.info(`Migrated dynamic cost memory for ${stateID} to variable-cost schema version 2`);
+		return migratedMemory;
+	}
+
+	/**
 	 * @param {string} stateID - Source state ID
 	 * @param {object} dynamicCosts - Unrounded dynamic cost memory
 	 */
@@ -600,7 +631,7 @@ class Sourceanalytix extends utils.Adapter {
 		await this.ensureDynamicCostMemoryState(stateID);
 		const memoryStateName = this.getDynamicCostMemoryStateName(stateID);
 		const payload = {
-			version: 1,
+			version: 2,
 			priceDefinition: this.activeStates[stateID].stateDetails.stateType,
 			lastReading: dynamicCosts.lastReading,
 			lastTs: dynamicCosts.lastTs,
@@ -651,16 +682,19 @@ class Sourceanalytix extends utils.Adapter {
 
 		const unitPrice = this.getNumberOrDefault(activeState.prices.unitPrice, 0);
 		const fallbackTotals = this.getFallbackDynamicCostTotals(readingNumber, activeState.calcValues, unitPrice);
+		const monthlyPrice = activeState.stateDetails.basicRate ? this.getNumberOrDefault(activeState.prices.basicPrice, 0) : 0;
+		const basicTotals = calculation.calculateBasicPriceTotals(monthlyPrice, new Date(readingTimestamp));
 		const stateRoot = `${activeState.stateDetails.deviceName}.currentYear.${activeState.stateDetails.financialCategory}`;
 		const totals = {
-			priceDay: await this.readCostStateOrFallback(`${stateRoot}.01_currentDay`, fallbackTotals.priceDay),
-			priceWeek: await this.readCostStateOrFallback(`${stateRoot}.02_currentWeek`, fallbackTotals.priceWeek),
-			priceMonth: await this.readCostStateOrFallback(`${stateRoot}.03_currentMonth`, fallbackTotals.priceMonth),
-			priceQuarter: await this.readCostStateOrFallback(`${stateRoot}.04_currentQuarter`, fallbackTotals.priceQuarter),
-			priceYear: await this.readCostStateOrFallback(`${stateRoot}.05_currentYear`, fallbackTotals.priceYear),
+			priceDay: await this.readVariableCostStateOrFallback(`${stateRoot}.01_currentDay`, fallbackTotals.priceDay, basicTotals.priceDay),
+			priceWeek: await this.readVariableCostStateOrFallback(`${stateRoot}.02_currentWeek`, fallbackTotals.priceWeek, basicTotals.priceWeek),
+			priceMonth: await this.readVariableCostStateOrFallback(`${stateRoot}.03_currentMonth`, fallbackTotals.priceMonth, basicTotals.priceMonth),
+			priceQuarter: await this.readVariableCostStateOrFallback(`${stateRoot}.04_currentQuarter`, fallbackTotals.priceQuarter, basicTotals.priceQuarter),
+			priceYear: await this.readVariableCostStateOrFallback(`${stateRoot}.05_currentYear`, fallbackTotals.priceYear, basicTotals.priceYear),
 		};
 
 		activeState.dynamicCosts = {
+			version: 2,
 			lastReading: readingNumber,
 			lastTs: readingTimestamp,
 			totals: totals

--- a/main.test.js
+++ b/main.test.js
@@ -5,11 +5,13 @@ const adapterHelpers = require('iobroker-adapter-helpers');
 const {
 	buildUnitConfig,
 	calculateBasicPriceTotals,
+	calculateVariablePriceTotals,
 	classifyCumulativeReading,
 	convertUnitValue,
 	getCurrentYearPeriodStateDefinitions,
 	getPeriodChanges,
 	initializePeriodStartValues,
+	migrateLegacyVariableCostTotals,
 	normalizePeriodSnapshot,
 	resolveCumulativeReading,
 } = require('./lib/calculation');
@@ -67,6 +69,7 @@ describe('dynamic pricing', () => {
 
 		it('rejects empty and non-numeric values', () => {
 			assert.equal(parsePriceValue(''), null);
+			assert.equal(parsePriceValue('   '), null);
 			assert.equal(parsePriceValue('invalid'), null);
 			assert.equal(parsePriceValue(false), null);
 		});
@@ -190,7 +193,7 @@ describe('dynamic pricing', () => {
 
 	describe('normalizeDynamicCostMemory', () => {
 		const preciseMemory = {
-			version: 1,
+			version: 2,
 			priceDefinition: 'Electricity',
 			lastReading: 7837.556,
 			lastTs: at(11),
@@ -223,8 +226,14 @@ describe('dynamic pricing', () => {
 			assert.equal(restoredMemory.totals.priceDay + priceDelta, 1.285789);
 		});
 
+		it('accepts legacy memory for migration', () => {
+			const legacyMemory = normalizeDynamicCostMemory({...preciseMemory, version: 1});
+			assert.ok(legacyMemory);
+			assert.equal(legacyMemory.version, 1);
+		});
+
 		it('rejects incompatible versions and incomplete totals', () => {
-			assert.equal(normalizeDynamicCostMemory({...preciseMemory, version: 2}), null);
+			assert.equal(normalizeDynamicCostMemory({...preciseMemory, version: 3}), null);
 			assert.equal(normalizeDynamicCostMemory({...preciseMemory, totals: {priceDay: 1}}), null);
 			assert.equal(normalizeDynamicCostMemory(null), null);
 		});
@@ -438,6 +447,75 @@ describe('period and cumulative calculations', () => {
 			assert.equal(totals.priceMonth, 31);
 			assert.equal(totals.priceQuarter, 31);
 			assert.equal(totals.priceYear, 124);
+		});
+
+		it('keeps the basic price separate from variable costs when restoring fixed prices', () => {
+			const variable = calculateVariablePriceTotals(5584.936, {
+				start_day: 5581.891,
+				start_week: 5581.891,
+				start_month: 5581.891,
+				start_quarter: 5581.891,
+				start_year: 5571,
+			}, 0.35);
+			const basic = calculateBasicPriceTotals(19.15, new Date(2026, 7, 1, 12));
+
+			assert.ok(Math.abs(variable.priceYear - 4.8776) < 1e-9);
+			assert.ok(Math.abs((variable.priceYear + basic.priceYear) - 158.0776) < 1e-9);
+			assert.notEqual(Math.round((variable.priceYear + basic.priceYear) * 100) / 100, 306.48);
+		});
+
+		it('treats empty legacy period starts as missing instead of zero', () => {
+			const variable = calculateVariablePriceTotals(5584.936, {
+				start_day: null,
+				start_week: '',
+				start_month: '   ',
+				start_quarter: undefined,
+				start_year: '5571,0',
+			}, '0,35');
+
+			assert.equal(variable.priceDay, 0);
+			assert.equal(variable.priceWeek, 0);
+			assert.equal(variable.priceMonth, 0);
+			assert.equal(variable.priceQuarter, 0);
+			assert.ok(Math.abs(variable.priceYear - 4.8776) < 1e-9);
+		});
+
+		it('removes an included basic price from dynamic and selector memories', () => {
+			const legacy = {priceDay: 1.5, priceWeek: 3, priceMonth: 12, priceQuarter: 31, priceYear: 124};
+			const basic = {priceDay: 1, priceWeek: 2, priceMonth: 10, priceQuarter: 30, priceYear: 120};
+			const expected = {priceDay: 0.5, priceWeek: 1, priceMonth: 2, priceQuarter: 1, priceYear: 4};
+
+			assert.deepEqual(migrateLegacyVariableCostTotals(legacy, basic, expected, 'state', 10, true), expected);
+			assert.deepEqual(migrateLegacyVariableCostTotals(legacy, basic, expected, 'selector', 10, true), expected);
+		});
+
+		it('does not subtract the basic price from an already variable legacy memory', () => {
+			const variable = {priceDay: 0.5, priceWeek: 1, priceMonth: 2, priceQuarter: 1, priceYear: 4};
+			const basic = {priceDay: 1, priceWeek: 2, priceMonth: 10, priceQuarter: 30, priceYear: 120};
+
+			assert.deepEqual(migrateLegacyVariableCostTotals(variable, basic, variable, 'state', 10, true), variable);
+			assert.deepEqual(migrateLegacyVariableCostTotals(variable, basic, {}, 'state', 10, true), variable);
+		});
+
+		it('preserves negative variable costs during legacy migration', () => {
+			const migrated = migrateLegacyVariableCostTotals(
+				{priceDay: 0.5, priceWeek: 1, priceMonth: 8, priceQuarter: 28, priceYear: 118},
+				{priceDay: 1, priceWeek: 2, priceMonth: 10, priceQuarter: 30, priceYear: 120},
+				{priceDay: -0.5, priceWeek: -1, priceMonth: -2, priceQuarter: -2, priceYear: -2},
+				'state',
+				10,
+				true,
+			);
+
+			assert.deepEqual(migrated, {priceDay: -0.5, priceWeek: -1, priceMonth: -2, priceQuarter: -2, priceYear: -2});
+		});
+
+		it('rebuilds one-price fixed memories and preserves memories without a basic price', () => {
+			const legacy = {priceDay: 1, priceWeek: 2, priceMonth: 3, priceQuarter: 4, priceYear: 5};
+			const fallback = {priceDay: 6, priceWeek: 7, priceMonth: 8, priceQuarter: 9, priceYear: 10};
+
+			assert.deepEqual(migrateLegacyVariableCostTotals(legacy, {}, fallback, 'static', 1, true), fallback);
+			assert.deepEqual(migrateLegacyVariableCostTotals(legacy, {}, fallback, 'state', 5, false), legacy);
 		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "io-package.json",
     "lib/calculation.js",
     "lib/dynamic-pricing.js",
+    "lib/statistics-json.js",
     "main.js"
   ],
   "dependencies": {

--- a/statistics-json.test.js
+++ b/statistics-json.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+	applyStatisticsState,
+	createStatisticsSnapshot,
+	serializeStatisticsSnapshot,
+} = require('./lib/statistics-json');
+
+function createSnapshot(overrides = {}) {
+	return createStatisticsSnapshot({
+		year: 2026,
+		sourceId: 'example.0.meter',
+		sourceName: {de: 'Stromzähler', en: 'Electricity meter'},
+		unit: 'kWh',
+		quantityType: 'consumed',
+		financialType: 'costs',
+		currency: 'EUR',
+		consumption: true,
+		costs: true,
+		meterValues: true,
+		days: true,
+		weeks: true,
+		months: true,
+		quarters: true,
+		previous: true,
+		...overrides,
+	});
+}
+
+describe('statistics JSON', () => {
+	it('creates the versioned schema with stable optional sections', () => {
+		const snapshot = createSnapshot();
+
+		assert.equal(snapshot.schemaVersion, 1);
+		assert.equal(snapshot.year, 2026);
+		assert.deepEqual(snapshot.source, {
+			id: 'example.0.meter',
+			name: 'Electricity meter',
+			unit: 'kWh',
+		});
+		assert.equal(snapshot.quantity.type, 'consumed');
+		assert.equal(snapshot.financial.type, 'costs');
+		assert.equal(snapshot.financial.currency, 'EUR');
+		assert.equal(snapshot.meterReadings.current, null);
+	});
+
+	it('uses null for disabled calculations and collections', () => {
+		const snapshot = createSnapshot({
+			consumption: false,
+			costs: false,
+			meterValues: false,
+			days: false,
+			weeks: false,
+			months: false,
+			quarters: false,
+			previous: false,
+		});
+
+		assert.equal(snapshot.quantity, null);
+		assert.equal(snapshot.financial, null);
+		assert.equal(snapshot.meterReadings, null);
+	});
+
+	it('maps current, previous and collection states to language-neutral keys', () => {
+		const snapshot = createSnapshot();
+
+		applyStatisticsState(snapshot, 'currentYear.consumed.01_currentDay', 4.2);
+		applyStatisticsState(snapshot, 'currentYear.consumed.03_previousMonth', 109.7);
+		applyStatisticsState(snapshot, 'currentYear.consumed.currentWeek.01_Monday', 1.1);
+		applyStatisticsState(snapshot, 'currentYear.consumed.previousWeek.07_Sunday', 2.2);
+		applyStatisticsState(snapshot, 'currentYear.consumed.weeks.7', 31.2);
+		applyStatisticsState(snapshot, 'currentYear.consumed.months.07_July', 114.3);
+		applyStatisticsState(snapshot, 'currentYear.consumed.quarters.Q3', 301.8);
+
+		assert.equal(snapshot.quantity.current.day, 4.2);
+		assert.equal(snapshot.quantity.previous.month, 109.7);
+		assert.equal(snapshot.quantity.periods.weekdays['1'], 1.1);
+		assert.equal(snapshot.quantity.periods.previousWeekdays['7'], 2.2);
+		assert.equal(snapshot.quantity.periods.weeks['07'], 31.2);
+		assert.equal(snapshot.quantity.periods.months['07'], 114.3);
+		assert.equal(snapshot.quantity.periods.quarters['3'], 301.8);
+	});
+
+	it('supports delivery, earnings and meter readings', () => {
+		const snapshot = createSnapshot({
+			quantityType: 'delivered',
+			financialType: 'earnings',
+		});
+
+		applyStatisticsState(snapshot, 'currentYear.delivered.05_currentYear', 894.1);
+		applyStatisticsState(snapshot, 'currentYear.earnings.02_currentWeek', 8.5);
+		applyStatisticsState(snapshot, 'cumulativeReading', 7837.6);
+		applyStatisticsState(snapshot, 'currentYear.meterReadings.01_previousDay', 7833.4);
+		applyStatisticsState(snapshot, 'currentYear.meterReadings.months.01_January', 7723.3);
+
+		assert.equal(snapshot.quantity.current.year, 894.1);
+		assert.equal(snapshot.financial.current.week, 8.5);
+		assert.equal(snapshot.meterReadings.current, 7837.6);
+		assert.equal(snapshot.meterReadings.previous.day, 7833.4);
+		assert.equal(snapshot.meterReadings.periods.months['01'], 7723.3);
+	});
+
+	it('ignores paths from inactive categories and serializes valid JSON', () => {
+		const snapshot = createSnapshot();
+
+		assert.equal(applyStatisticsState(snapshot, 'currentYear.delivered.01_currentDay', 99), false);
+		assert.equal(snapshot.quantity.current.day, null);
+		assert.deepEqual(JSON.parse(serializeStatisticsSnapshot(snapshot)), snapshot);
+	});
+});


### PR DESCRIPTION
## Summary

Adds one compact, automatically maintained statistics JSON state per active source. This allows VIS, scripts and other adapters to access current SourceAnalytix results without reading many individual states.

No additional Admin or custom-setting switch is introduced.

## Related issues

- Closes #361
- Closes #967

## Changes

- Create `<source>.statisticsJson` automatically for every active source.
- Use a read-only string state with role `json`.
- Provide a versioned, language-neutral schema.
- Include current and optional previous day, week, month, quarter and year values.
- Include enabled weekday, week, month and quarter collections.
- Support consumption/cost and delivery/earnings configurations.
- Include optional meter readings and the current cumulative reading.
- Represent disabled calculations and collections as `null`.
- Limit the payload to the current calendar year.
- Rebuild the JSON from existing states after startup or configuration changes.
- Refresh it after calculations and recovered calendar rollovers.
- Retain the last JSON when a source is disabled or deleted.
- Bundle internal updates into one delayed write and skip unchanged payloads.
- Document the schema and lifecycle in the README.

## Schema

The state uses `schemaVersion: 1` and contains:

- `source`: original state ID, display name and unit
- `quantity`: `consumed` or `delivered` statistics
- `financial`: `costs` or `earnings` statistics and currency
- `meterReadings`: current and optional period meter values

Period keys are language-independent:

- weekdays: `1` through `7`
- weeks: `01` through `53`
- months: `01` through `12`
- quarters: `1` through `4`

The JSON mirrors existing calculated states and performs no independent calculation.

## Validation

- Unit and package tests pass.
- TypeScript validation and ESLint pass without warnings.
- Live-tested with two existing active SourceAnalytix sources.