### PR TITLE
fix: stamp previous period values at 23:59:59 (#497)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ For every source, SourceAnalytix creates a `cumulativeReading` and the enabled r
 
 The basic current and optional previous states use names such as `01_currentDay`, `02_currentWeek`, `03_currentMonth`, `04_currentQuarter`, `05_currentYear` and their `previous` equivalents.
 
+Previous values are written with the timestamp of the period they belong to, `23:59:59` on its last day, instead of the moment the rollover happens. History adapters therefore log a completed day, week, month, quarter or year inside that period, which is what visualizations such as Flot expect.
+
 ### Statistics JSON
 
 Every active source automatically exposes a read-only `statisticsJson` state with role `json`; no additional setting is required. It contains the same calculated values as the individual states and does not perform a separate calculation.
@@ -315,6 +317,9 @@ This is a personal donation link for DutchmanNL and is not related to the ioBrok
     ### __WORK IN PROGRESS__
 -->
 ## Changelog
+### __WORK IN PROGRESS__
+* Previous day, week, month, quarter and year values are written with the timestamp of the period they belong to (23:59:59 on its last day), so history adapters and Flot plot them in the correct period ([#497](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/497)).
+
 ### 0.5.4 (2026-08-01)
 * Each active source automatically exposes a compact `statisticsJson` state containing its current-year quantity, financial and optional meter-reading statistics ([#361](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/361), [#967](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/967)).
 * Monthly basic prices are no longer imported into the variable-cost accumulator and added a second time after a restart ([#1188](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/1188)).

--- a/lib/calculation.js
+++ b/lib/calculation.js
@@ -82,6 +82,25 @@ function getPeriodChanges(previous, current) {
 }
 
 /**
+ * Local midnight of the day a rollover is processed on.
+ * @param {Date} date - Local date of the rollover
+ * @returns {number} Unix timestamp of the period boundary
+ */
+function getPeriodBoundaryTimestamp(date) {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+/**
+ * Timestamp the completed period is stamped with, so previous values are logged
+ * inside the period they belong to instead of at the start of the new one.
+ * @param {Date} date - Local date of the rollover
+ * @returns {number} Unix timestamp of 23:59:59 on the last day of the completed period
+ */
+function getPreviousPeriodTimestamp(date) {
+	return getPeriodBoundaryTimestamp(date) - 1000;
+}
+
+/**
  * Validate period identifiers restored from persistent adapter state.
  * @param {unknown} value - Persisted period snapshot
  * @returns {{date?: string, day: string, week: string, month: string, quarter: number, year: number} | null} Normalized snapshot
@@ -411,7 +430,9 @@ module.exports = {
 	classifyCumulativeReading,
 	convertUnitValue,
 	getCurrentYearPeriodStateDefinitions,
+	getPeriodBoundaryTimestamp,
 	getPeriodChanges,
+	getPreviousPeriodTimestamp,
 	initializePeriodStartValues,
 	migrateLegacyVariableCostTotals,
 	normalizePeriodSnapshot,

--- a/main.js
+++ b/main.js
@@ -1675,8 +1675,9 @@ class Sourceanalytix extends utils.Adapter {
 	 * Copy completed generic periods to their configured previous-period states.
 	 * @param {object} stateDetails - Active state details
 	 * @param {object} changes - Changed calendar periods
+	 * @param {number} [previousPeriodTimestamp] - Timestamp of the completed period
 	 */
-	async copyPreviousPeriodStates(stateDetails, changes) {
+	async copyPreviousPeriodStates(stateDetails, changes, previousPeriodTimestamp) {
 		if (!this.config.currentYearPrevious) return;
 		const periods = [
 			['day', '01_currentDay', '01_previousDay'],
@@ -1689,14 +1690,14 @@ class Sourceanalytix extends utils.Adapter {
 			if (!changes[period]) continue;
 			if (stateDetails.consumption) {
 				const root = `${stateDetails.deviceName}.currentYear.${stateDetails.headCategory}`;
-				await this.setPreviousValues(`${root}.${currentState}`, `${root}.${previousState}`);
+				await this.setPreviousValues(`${root}.${currentState}`, `${root}.${previousState}`, previousPeriodTimestamp);
 			}
 			if (stateDetails.costs) {
 				const root = `${stateDetails.deviceName}.currentYear.${stateDetails.financialCategory}`;
-				await this.setPreviousValues(`${root}.${currentState}`, `${root}.${previousState}`);
+				await this.setPreviousValues(`${root}.${currentState}`, `${root}.${previousState}`, previousPeriodTimestamp);
 			}
 			if (stateDetails.meter_values) {
-				await this.setPreviousValues(`${stateDetails.deviceName}.cumulativeReading`, `${stateDetails.deviceName}.currentYear.meterReadings.${previousState}`);
+				await this.setPreviousValues(`${stateDetails.deviceName}.cumulativeReading`, `${stateDetails.deviceName}.currentYear.meterReadings.${previousState}`, previousPeriodTimestamp);
 			}
 		}
 	}
@@ -1705,8 +1706,9 @@ class Sourceanalytix extends utils.Adapter {
 	 * Move weekday values to previousWeek and clear the new week.
 	 * @param {object} stateDetails - Active state details
 	 * @param {boolean} weekChanged - Whether a new week started
+	 * @param {number} [previousPeriodTimestamp] - Timestamp of the completed week
 	 */
-	async resetCurrentWeekdayStates(stateDetails, weekChanged) {
+	async resetCurrentWeekdayStates(stateDetails, weekChanged, previousPeriodTimestamp) {
 		if (!weekChanged || !this.config.currentYearDays) return;
 		for (const weekday of weekdays) {
 			const stateRoots = [];
@@ -1716,7 +1718,7 @@ class Sourceanalytix extends utils.Adapter {
 			for (const root of stateRoots) {
 				const currentState = `${stateDetails.deviceName}.currentYear.${root}.currentWeek.${weekday}`;
 				if (this.config.currentYearPrevious) {
-					await this.setPreviousValues(currentState, `${stateDetails.deviceName}.currentYear.${root}.previousWeek.${weekday}`);
+					await this.setPreviousValues(currentState, `${stateDetails.deviceName}.currentYear.${root}.previousWeek.${weekday}`, previousPeriodTimestamp);
 				}
 				await this.setStateAsync(currentState, {val: 0, ack: true});
 			}
@@ -1859,9 +1861,11 @@ class Sourceanalytix extends utils.Adapter {
 		}
 
 		this.log.info(`Processing calendar rollover for ${stateID}: ${JSON.stringify(changes)}`);
+		const boundaryTimestamp = calculation.getPeriodBoundaryTimestamp(date);
+		const previousPeriodTimestamp = calculation.getPreviousPeriodTimestamp(date);
 		if (changes.year) await this.initializeYearStatisticsStates(stateID);
-		await this.copyPreviousPeriodStates(stateDetails, changes);
-		await this.resetCurrentWeekdayStates(stateDetails, changes.week);
+		await this.copyPreviousPeriodStates(stateDetails, changes, previousPeriodTimestamp);
+		await this.resetCurrentWeekdayStates(stateDetails, changes.week, previousPeriodTimestamp);
 		await this.resetCurrentYearCollectionStates(stateDetails, changes.year);
 
 		const newCalcValues = {
@@ -1878,7 +1882,6 @@ class Sourceanalytix extends utils.Adapter {
 		}
 
 		activeState.calcValues = newCalcValues;
-		const boundaryTimestamp = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
 		if (this.usesHistoricalCostCalculation(stateID)) {
 			await this.ensureDynamicCostMemory(stateID, Number(reading), boundaryTimestamp);
 		}
@@ -1978,8 +1981,9 @@ class Sourceanalytix extends utils.Adapter {
 	 * Function to handle previousState values
 	 * @param {string} currentState - RAW state ID currentValue
 	 * @param {string} [previousState] - RAW state ID previousValue
+	 * @param {number} [timestamp] - Timestamp of the completed period, defaults to now
 	 */
-	async setPreviousValues(currentState, previousState) {
+	async setPreviousValues(currentState, previousState, timestamp) {
 		// Only set previous state if option is chosen
 		try {
 			if (this.config.currentYearPrevious) {
@@ -1988,10 +1992,12 @@ class Sourceanalytix extends utils.Adapter {
 					// Get value of currentState
 					const currentVal = await this.getStateAsync(currentState);
 					if (currentVal) {
-						// Set current value to previous state
+						// Set current value to previous state, stamped at the end of the
+						// period it belongs to so history adapters plot it there
 						await this.setStateAsync(previousState, {
 							val: currentVal.val,
-							ack: true
+							ack: true,
+							...(Number.isFinite(timestamp) ? {ts: timestamp} : {})
 						});
 					}
 				} else {

--- a/main.test.js
+++ b/main.test.js
@@ -9,7 +9,9 @@ const {
 	classifyCumulativeReading,
 	convertUnitValue,
 	getCurrentYearPeriodStateDefinitions,
+	getPeriodBoundaryTimestamp,
 	getPeriodChanges,
+	getPreviousPeriodTimestamp,
 	initializePeriodStartValues,
 	migrateLegacyVariableCostTotals,
 	normalizePeriodSnapshot,
@@ -298,6 +300,42 @@ describe('period and cumulative calculations', () => {
 			assert.equal(normalizePeriodSnapshot({
 				date: 'not-a-date', day: '01_Monday', week: '31', month: '07_July', quarter: 3, year: 2026,
 			}), null);
+		});
+	});
+
+	describe('previous period timestamps', () => {
+		it('stamps completed periods at 23:59:59 of their last day', () => {
+			const rolloverDate = new Date(2026, 6, 29, 0, 0, 0, 120);
+			const previous = new Date(getPreviousPeriodTimestamp(rolloverDate));
+			assert.equal(previous.getFullYear(), 2026);
+			assert.equal(previous.getMonth(), 6);
+			assert.equal(previous.getDate(), 28);
+			assert.equal(previous.getHours(), 23);
+			assert.equal(previous.getMinutes(), 59);
+			assert.equal(previous.getSeconds(), 59);
+		});
+
+		it('stays inside the completed month and year at their boundaries', () => {
+			const newYear = new Date(getPreviousPeriodTimestamp(new Date(2027, 0, 1, 0, 0, 3)));
+			assert.equal(newYear.getFullYear(), 2026);
+			assert.equal(newYear.getMonth(), 11);
+			assert.equal(newYear.getDate(), 31);
+
+			const newMonth = new Date(getPreviousPeriodTimestamp(new Date(2026, 2, 1, 0, 0, 0)));
+			assert.equal(newMonth.getMonth(), 1);
+			assert.equal(newMonth.getDate(), 28);
+		});
+
+		it('uses the current day for a rollover recovered later in the day', () => {
+			const recovered = new Date(2026, 6, 29, 10, 42, 17);
+			assert.equal(
+				getPeriodBoundaryTimestamp(recovered),
+				new Date(2026, 6, 29).getTime(),
+			);
+			assert.equal(
+				getPreviousPeriodTimestamp(recovered),
+				getPeriodBoundaryTimestamp(recovered) - 1000,
+			);
 		});
 	});
 


### PR DESCRIPTION
## Summary

`previousDay`, `previousWeek`, `previousMonth`, `previousQuarter` and `previousYear` were written at the moment of the rollover, i.e. `00:00:00` of the **new** period. History adapters therefore logged a completed period at the start of the following one, and Flot plots days, weeks, months and years shifted by one period — the problem reported in #497.

Previous values are now stamped with the timestamp of the period they belong to: `23:59:59` on its last day.

## Changes

- Add `getPeriodBoundaryTimestamp()` and `getPreviousPeriodTimestamp()` to `lib/calculation.js`. The boundary expression already existed inline in `processPeriodRollover()` for the dynamic cost memory and is now shared.
- `setPreviousValues()` accepts an optional timestamp and passes it as `ts` to `setStateAsync()`. Without a timestamp the previous behaviour is unchanged.
- Thread the timestamp through `copyPreviousPeriodStates()` and `resetCurrentWeekdayStates()`.
- Document the behaviour in the README and add the changelog entry.

## Deliberately unchanged

- The weekday zeroing and `resetCurrentYearCollectionStates()` write **current**-period values, so they keep the default timestamp.
- Stored values are identical, only their timestamp changes, so no new option is introduced and existing history is untouched.
- For a rollover recovered after downtime the timestamp is 23:59:59 of the day before the restart, consistent with the existing catch-up (not back-fill) recovery design.

## Validation

- 3 new unit tests: normal midnight rollover, month and year boundaries, and a rollover recovered later in the day (67 passing, was 64).
- `npm run lint`, `npm run check` and `npm test` pass.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)