### PR TITLE
feat: run a missed rollover without restarting (#905, #904)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ When the adapter crashes or another code error occurs, the error message which a
 - Timestamped price history which preserves already calculated costs
 - Automatic conversion between compatible energy, volume, mass and metric length units
 - Integration of power readings over their actual update intervals, optionally ignoring negative readings
-- Recovery of missed calendar rollovers after an adapter restart
+- Recovery of missed calendar rollovers after a restart, on request or by an hourly check
 - Handling of meter resets, meter replacements and small backwards fluctuations
 - One compact, automatically updated statistics JSON state per active source
 
@@ -52,6 +52,13 @@ The **General settings** tab controls which detailed statistics are created. Dis
 Both rounding settings accept `-1` to store the exact calculated value without rounding. A single source can deviate from them: its **Decimals for consumption values** and **Decimals for cost values** fields override the global setting and use it whenever they are left empty. Rounding only affects the values written to states; internal calculations, the cumulative reading and the persisted memories always keep full precision, so no accuracy is lost over time.
 
 SourceAnalytix remembers the last successfully processed calendar periods. If the adapter or ioBroker is not running at midnight, missed day, week, month, quarter and year changes are processed once at the next start.
+
+A rollover can also be triggered without restarting the instance, which is useful when the instance is noticed to be down shortly after midnight:
+
+- Set `sourceanalytix.<instance>.info.recoverPeriods` to `true`. The button resets itself when the run is finished.
+- Or send a message from a script: `sendTo('sourceanalytix.<instance>', 'recoverPeriods', {}, result => log(result.recovered))`. The reply contains the number of sources whose rollover was processed.
+
+An hourly check performs the same recovery on its own, so a rollover missed while the adapter kept running - after a host suspend or a system time correction - is corrected automatically. Every route is idempotent: sources whose periods are already up to date are skipped.
 
 ### 2. Create price definitions
 
@@ -324,6 +331,8 @@ This is a personal donation link for DutchmanNL and is not related to the ioBrok
 ### __WORK IN PROGRESS__
 * Previous day, week, month, quarter and year values are written with the timestamp of the period they belong to (23:59:59 on its last day), so history adapters and Flot plot them in the correct period ([#497](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/497)).
 * The number of decimals for consumption and cost values is configurable globally and per source, including an option to store the exact value without rounding ([#934](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/934)).
+* A missed calendar rollover can be processed without restarting the instance, through the new `info.recoverPeriods` button or a `recoverPeriods` message, and an hourly check recovers a rollover the scheduler missed while the adapter kept running ([#905](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/905)).
+* The midnight scheduler can no longer raise an unhandled rejection, and its cron job and timers are stopped when the instance shuts down ([#904](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/904)).
 
 ### 0.5.4 (2026-08-01)
 * Each active source automatically exposes a compact `statisticsJson` state containing its current-year quantity, financial and optional meter-reading statistics ([#361](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/361), [#967](https://github.com/DrozmotiX/ioBroker.sourceanalytix/issues/967)).

--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ const basicPreviousStates = ['01_previousDay', '02_previousWeek', '03_previousMo
 const weekdays = JSON.parse('["07_Sunday","01_Monday","02_Tuesday","03_Wednesday","04_Thursday","05_Friday","06_Saturday"]');
 const months = JSON.parse('["01_January","02_February","03_March","04_April","05_May","06_June","07_July","08_August","09_September","10_October","11_November","12_December"]');
 const stateDeletion = true, previousCalculationRounded = {};
+const recoverPeriodsState = 'info.recoverPeriods';
 const storeSettings = {};
 let calcBlock = null; // Global variable to block all calculations
 let delay = null; // Global array for all running timers
@@ -57,6 +58,9 @@ class Sourceanalytix extends utils.Adapter {
 		this.priceHistories = {}; // Price definition category -> ordered price history
 		this.validStates = {}; // Array of all created states
 		this.visWidgetJson ={}; // Array containing all calculation values to use in vis widget
+		this.resetDayJob = null; // Midnight cron job
+		this.periodCheckInterval = null; // Hourly safety check for missed rollovers
+		this.rolloverRunning = false; // Guard against concurrent rollovers
 		this.statisticsJsonSnapshots = {};
 		this.statisticsJsonTimers = {};
 		this.statisticsJsonLastValues = {};
@@ -152,6 +156,9 @@ class Sourceanalytix extends utils.Adapter {
 				}
 				count = count + 1;
 			}
+
+			// Provide the manual rollover button before the scheduler is started
+			await this.ensureRecoverPeriodsState();
 
 			// Start Daily reset function by cron job
 			await this.resetStartValues();
@@ -1635,6 +1642,17 @@ class Sourceanalytix extends utils.Adapter {
 	 * @param {ioBroker.State | null | undefined} state - Changed state, or null when deleted
 	 */
 	async onStateChange(id, state) {
+		// Handled before the calculation block, a manual rollover must always be possible
+		if (state && !state.ack && id === `${this.namespace}.${recoverPeriodsState}`) {
+			try {
+				this.log.info(`Manual period rollover requested`);
+				await this.runPeriodRollovers('button');
+				await this.setStateAsync(recoverPeriodsState, {val: false, ack: true});
+			} catch (error) {
+				this.errorHandling(`[onStateChange] for ${id}`, error);
+			}
+			return;
+		}
 		if (calcBlock) return; // cancel operation if global calculation block is activate
 		try {
 			// Check if a valid state change has been received
@@ -1953,31 +1971,98 @@ class Sourceanalytix extends utils.Adapter {
 	 */
 	async resetStartValues() {
 		try {
-			const resetDay = new schedule('0 0 * * *', async () => {
-				calcBlock = true;
-				const date = new Date();
-				await this.refreshDates();
-				for (const stateID in this.activeStates) {
-					try {
-						await this.processPeriodRollover(stateID, date);
-					} catch (error) {
-						this.errorHandling(`[resetStartValues] ${stateID}`, error);
-					}
+			// The cron library does not await the callback, so it must never reject.
+			this.resetDayJob = new schedule('0 0 * * *', async () => {
+				try {
+					await this.runPeriodRollovers('midnight scheduler');
+				} catch (error) {
+					this.errorHandling(`[resetStartValues]`, error);
+					calcBlock = false; // Continue all calculations
 				}
-
-				if (delay) this.clearTimeout(delay);
-				delay = this.setTimeout(() => {
-					calcBlock = false;
-				}, 500);
 			});
 
-			resetDay.start();
+			this.resetDayJob.start();
+
+			// Recover a rollover the scheduler could have missed while the adapter kept
+			// running, for example after a host suspend or a system time correction.
+			this.periodCheckInterval = this.setInterval(async () => {
+				try {
+					await this.runPeriodRollovers('safety check');
+				} catch (error) {
+					this.errorHandling(`[periodCheck]`, error);
+					calcBlock = false;
+				}
+			}, 3600000);
 
 		} catch (error) {
 			this.errorHandling(`[resetStartValues]`, error);
 			calcBlock = false; // Continue all calculations
 		}
 
+	}
+
+	/**
+	 * Process a calendar rollover for all active sources, from the scheduler,
+	 * the safety check, the button state or a sendTo message.
+	 * @param {string} trigger - What asked for the rollover, used for logging
+	 * @returns {Promise<number>} Number of sources with a processed rollover
+	 */
+	async runPeriodRollovers(trigger) {
+		if (this.rolloverRunning) {
+			this.log.debug(`[runPeriodRollovers] Rollover already running, ignoring ${trigger}`);
+			return 0;
+		}
+		this.rolloverRunning = true;
+		calcBlock = true;
+		let recovered = 0;
+		try {
+			const date = new Date();
+			await this.refreshDates();
+			for (const stateID in this.activeStates) {
+				try {
+					if (await this.processPeriodRollover(stateID, date)) recovered = recovered + 1;
+				} catch (error) {
+					this.errorHandling(`[runPeriodRollovers] ${stateID}`, error);
+				}
+			}
+		} finally {
+			this.rolloverRunning = false;
+			if (delay) this.clearTimeout(delay);
+			delay = this.setTimeout(() => {
+				calcBlock = false;
+			}, 500);
+		}
+
+		if (recovered > 0) {
+			this.log.info(`Processed calendar rollover for ${recovered} source(s), triggered by ${trigger}`);
+		} else {
+			this.log.debug(`[runPeriodRollovers] No rollover needed, triggered by ${trigger}`);
+		}
+		return recovered;
+	}
+
+	/**
+	 * Create the button which runs a missed rollover without restarting the instance.
+	 */
+	async ensureRecoverPeriodsState() {
+		await this.extendObjectAsync('info', {
+			type: 'channel',
+			common: {name: 'Information'},
+			native: {},
+		});
+		await this.extendObjectAsync(recoverPeriodsState, {
+			type: 'state',
+			common: {
+				name: 'Run missed period rollover',
+				type: 'boolean',
+				role: 'button',
+				read: false,
+				write: true,
+				def: false,
+			},
+			native: {},
+		});
+		this.subscribeStates(recoverPeriodsState);
 	}
 
 	/**
@@ -2748,6 +2833,13 @@ class Sourceanalytix extends utils.Adapter {
 						this.sendTo(obj.from, obj.command, unitArray, obj.callback);
 					}
 					break;
+
+				case 'recoverPeriods': {
+					this.log.info(`Period rollover requested by ${obj.from}`);
+					const recovered = await this.runPeriodRollovers(`message from ${obj.from}`);
+					if (obj.callback) this.sendTo(obj.from, obj.command, {recovered}, obj.callback);
+					break;
+				}
 			}
 		}
 	}
@@ -2758,6 +2850,18 @@ class Sourceanalytix extends utils.Adapter {
 	 */
 	onUnload(callback) {
 		try {
+			if (this.resetDayJob) {
+				this.resetDayJob.stop();
+				this.resetDayJob = null;
+			}
+			if (this.periodCheckInterval) {
+				this.clearInterval(this.periodCheckInterval);
+				this.periodCheckInterval = null;
+			}
+			if (delay) {
+				this.clearTimeout(delay);
+				delay = null;
+			}
 			for (const timer of Object.values(this.statisticsJsonTimers)) {
 				this.clearTimeout(timer);
 			}


### PR DESCRIPTION
## Summary

A missed midnight rollover could only be recovered by restarting the instance: `processPeriodRollover()` was reachable from the cron callback and from `initialize()`, and nowhere else. #905 asks for exactly that recovery on demand, for when the instance is noticed to be down shortly after midnight.

## Changes

Three routes into the same idempotent rollover, all sharing the new `runPeriodRollovers()`:

- **Button state** `info.recoverPeriods` — handled at the top of `onStateChange()`, *before* the `calcBlock` early return, so a manual run works even while calculations are blocked. Resets itself to `false` when the run finishes.
- **`recoverPeriods` sendTo command** — replies with `{recovered: <number of sources>}` for use from scripts.
- **Hourly safety check** — recovers a rollover the scheduler missed while the adapter kept running, e.g. after a host suspend or a system time correction.

A `rolloverRunning` guard keeps the routes from overlapping, and the `calcBlock` release moves into a `finally` block, so a throwing source can no longer leave calculations permanently blocked.

## Hardening for #904

- The `cron` library does not await its callback. An error escaping the per-source `try/catch` surfaced as an unhandled rejection rather than an adapter log entry; the callback body is now wrapped.
- The cron job was a local `const` and was never stopped. It, the new interval and the pending `calcBlock` timer are now cleared in `onUnload()`.

The crash originally reported in #904 is not reproducible against the current code — the adapter has no filesystem I/O left at all, and its practical consequence (no calculations after a missed midnight) was already addressed by the restart recovery in 0.5.1. This PR removes the remaining way the scheduler could fail silently.

## Validation

- `npm run lint`, `npm run check`, `npm test` (72 + 58) pass.
- `npm run test:integration` passes: the adapter starts, creates the button state and terminates cleanly with the new teardown.
- The rollover paths themselves are adapter plumbing around the already unit-tested `processPeriodRollover()`, so no new unit tests were added — the pure period logic they call is covered by the existing `getPeriodChanges` / `normalizePeriodSnapshot` / previous-period-timestamp suites.

Closes #905
Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)